### PR TITLE
fix potential deadlock

### DIFF
--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionImpl.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionImpl.java
@@ -172,6 +172,9 @@ public class StoreSessionImpl implements StoreSession {
                     } catch (InterruptedException ex) {
                         Thread.interrupted();
                     }
+                    if (!running) {
+                        return;
+                    }
                 }
 
                 if (requestQueue.enqueue(request)) {

--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionImpl.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionImpl.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
 
 /**
  * Implements {@link StoreSession}.
@@ -34,7 +34,7 @@ public class StoreSessionImpl implements StoreSession {
     private final int quorum;
     private final ArrayList<ReplicaSession> replicaSessions;
     private final StoreSessionTask task;
-    private final RequestQueue<StoreAppendRequest> requestQueue = new RequestQueue<>(new ArrayBlockingQueue<>(BATCH_SIZE * 2));
+    private final RequestQueue<StoreAppendRequest> requestQueue = new RequestQueue<>(new LinkedBlockingDeque<>());
     private final Object requestQueueProcessingLock = new Object();
 
     private LatencyWeightedRouter<ReplicaSession> router = null;
@@ -163,6 +163,15 @@ public class StoreSessionImpl implements StoreSession {
             if (running) {
                 if (request.reqId.generation() != generation) {
                     throw new GenerationMismatchException();
+                }
+
+                // Wait until the queue has enough space.
+                while (requestQueue.size() > BATCH_SIZE * 2) {
+                    try {
+                        wait();
+                    } catch (InterruptedException ex) {
+                        Thread.interrupted();
+                    }
                 }
 
                 if (requestQueue.enqueue(request)) {


### PR DESCRIPTION
To explain the cause, we need to understand three methods.

1) `append()` enqueue append task to queue.
2) `doAppend` dequeue append task from queue.
3) `resolveAppendRequests()` commits transaction.
4) `append()`, `doAppend`  and `resolveAppendRequests()` share the lock.
5) when append queue is full, `append()` will `wait()` while calling `queue.enqueue()`, which is fine. Because normally, `doAppend()` will unblock `append()` by calling `queue.dequeue(BATCH_SIZE)`
6) however, there is a corner case when load is heavy. When `append()` was called many times in a short time and gets blocked due to queue full, it holds the lock so neither `resolveAppendRequests()` nor `doAppend()` could move forward.
7) finally, we have a deadlock

To fix it, we need to tell `append()` to give up on it lock when the queue is "almost full". 