### PR TITLE
added onApplication and onLockFailure to TransactionContext

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/TransactionContext.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/TransactionContext.java
@@ -69,7 +69,12 @@ public abstract class TransactionContext {
     }
 
     /**
-     * A method that is call on failure of optimistic locking
+     * A method that is called on failure of optimistic locking.
+     * There can be a spurious lock failure with a very small probability.
+     * A spurious lock failure is the case that the lock has failed even though the locks high-water mark has not been changed.
+     * So, this callback should treated as an informational notification.
+     * Waltz client will automatically invoke the execute method again after the client consumed a transaction that
+     * caused the lock failure. And the execute method should decide whether the transaction should be retried or aborted.
      */
     public void onLockFailure() {
     }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/TransactionContext.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/TransactionContext.java
@@ -53,12 +53,25 @@ public abstract class TransactionContext {
     }
 
     /**
+     * A method that is called on application of transaction through
+     * {@link WaltzClientCallbacks#applyTransaction(Transaction)}.
+     */
+    public void onApplication() {
+    }
+
+    /**
      * A method that is called on exception.
      * After this call, no retry will be attempted by the Waltz client.
      *
      * @param ex The exception that was thrown.
      */
     public void onException(Throwable ex) {
+    }
+
+    /**
+     * A method that is call on failure of optimistic locking
+     */
+    public void onLockFailure() {
     }
 
 }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClient.java
@@ -147,7 +147,7 @@ public class WaltzClient {
             AppendRequest request = build(context);
 
             if (request != null) {
-                streamClient.append(request)
+                streamClient.append(request, context)
                     .whenComplete(new TransactionResultHandlerImpl(context));
             } else {
                 // Completed with no append. There will be no retry.

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalStreamClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalStreamClient.java
@@ -101,11 +101,11 @@ public class InternalStreamClient extends InternalBaseClient implements StreamCl
      * @return a {@link TransactionFuture} which completes when the append response is processed.
      */
     @Override
-    public TransactionFuture append(AppendRequest request) {
+    public TransactionFuture append(AppendRequest request, TransactionContext context) {
         Partition partition = getPartition(request.reqId.partitionId());
 
         while (true) {
-            TransactionFuture future = partition.append(request);
+            TransactionFuture future = partition.append(request, context);
 
             if (future != null) {
                 return future;

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/StreamClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/StreamClient.java
@@ -18,7 +18,7 @@ public interface StreamClient {
 
     TransactionBuilderImpl getTransactionBuilder(TransactionContext context);
 
-    TransactionFuture append(AppendRequest request);
+    TransactionFuture append(AppendRequest request, TransactionContext context);
 
     void flushTransactions();
 

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/TransactionFuture.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/TransactionFuture.java
@@ -1,5 +1,6 @@
 package com.wepay.waltz.client.internal;
 
+import com.wepay.waltz.client.TransactionContext;
 import com.wepay.waltz.common.message.ReqId;
 
 import java.util.concurrent.CompletableFuture;
@@ -10,6 +11,7 @@ import java.util.concurrent.CompletableFuture;
 public class TransactionFuture extends CompletableFuture<Boolean> {
 
     public final ReqId reqId;
+    public final TransactionContext transactionContext;
 
     private boolean flushed = false;
 
@@ -18,8 +20,9 @@ public class TransactionFuture extends CompletableFuture<Boolean> {
      *
      * @param reqId the id of the request.
      */
-    public TransactionFuture(ReqId reqId) {
+    public TransactionFuture(ReqId reqId, TransactionContext transactionContext) {
         this.reqId = reqId;
+        this.transactionContext = transactionContext;
     }
 
     /**

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/TransactionMonitor.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/TransactionMonitor.java
@@ -195,7 +195,7 @@ public class TransactionMonitor {
         synchronized (this) {
             TransactionFuture future = registered.get(reqId);
             if (future != null) {
-                return future.transactionContext;
+                return future.getTransactionContext();
             }
             return null;
         }
@@ -210,15 +210,20 @@ public class TransactionMonitor {
     public TransactionContext committed(ReqId reqId) {
         synchronized (this) {
             TransactionFuture future = registered.get(reqId);
+            TransactionContext context = null;
             if (state != State.CLOSED) {
                 if (future != null) {
                     // This is own transaction
+                    context = future.getTransactionContext();
+                    if (context == null) {
+                        logger.error("missing transaction context");
+                    }
                     complete(reqId, true);
                     notifyAll();
                 }
             }
 
-            return future == null ? null : future.transactionContext;
+            return context;
         }
     }
 

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/TransactionMonitor.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/TransactionMonitor.java
@@ -206,6 +206,7 @@ public class TransactionMonitor {
      * the corresponding {@link TransactionFuture} of the {@code reqId} is completed with {@code true}.
      *
      * @param reqId the {@code ReqId} of the transaction that was committed to a Waltz server.
+     * @return the transaction context associated with this reqId, null if not found.
      */
     public TransactionContext committed(ReqId reqId) {
         synchronized (this) {

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/TransactionMonitor.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/TransactionMonitor.java
@@ -1,6 +1,7 @@
 package com.wepay.waltz.client.internal;
 
 import com.wepay.riff.util.Logging;
+import com.wepay.waltz.client.TransactionContext;
 import com.wepay.waltz.common.message.ReqId;
 import com.wepay.waltz.exception.ClientClosedException;
 import com.wepay.waltz.exception.PartitionInactiveException;
@@ -138,7 +139,7 @@ public class TransactionMonitor {
      * @return a {@link TransactionFuture} which will complete when the corresponding transaction is {@link #committed(ReqId)}.
      *         Or, a {@code null}, if {@code registrationTimeout} has passed before registration.
      */
-    public TransactionFuture register(ReqId reqId, long registrationTimeout) {
+    public TransactionFuture register(ReqId reqId, TransactionContext context, long registrationTimeout) {
         synchronized (this) {
             final long due = System.currentTimeMillis() + registrationTimeout;
             while (state == State.STARTED && (numRegistered >= maxConcurrentTransactions)) {
@@ -155,7 +156,7 @@ public class TransactionMonitor {
                 }
             }
 
-            TransactionFuture future = new TransactionFuture(reqId);
+            TransactionFuture future = new TransactionFuture(reqId, context);
 
             if (state == State.STARTED) {
                 if (!registered.containsKey(reqId)) {
@@ -185,20 +186,39 @@ public class TransactionMonitor {
     }
 
     /**
+     * Returns the {@link TransactionContext} associated the specified {@code reqId}.
+     *
+     * @param reqId the {@code ReqId} of the transaction
+     * @return the transaction context associated with this reqId, null if not found
+     */
+    public TransactionContext getTransactionContext(ReqId reqId) {
+        synchronized (this) {
+            TransactionFuture future = registered.get(reqId);
+            if (future != null) {
+                return future.transactionContext;
+            }
+            return null;
+        }
+    }
+
+    /**
      * If the transaction monitor is not closed,
      * the corresponding {@link TransactionFuture} of the {@code reqId} is completed with {@code true}.
      *
      * @param reqId the {@code ReqId} of the transaction that was committed to a Waltz server.
      */
-    public void committed(ReqId reqId) {
+    public TransactionContext committed(ReqId reqId) {
         synchronized (this) {
+            TransactionFuture future = registered.get(reqId);
             if (state != State.CLOSED) {
-                if (registered.containsKey(reqId)) {
+                if (future != null) {
                     // This is own transaction
                     complete(reqId, true);
                     notifyAll();
                 }
             }
+
+            return future == null ? null : future.transactionContext;
         }
     }
 

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockDriver.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockDriver.java
@@ -131,6 +131,13 @@ public class MockDriver implements WaltzClientDriver {
     }
 
     /**
+     * Forces the next lock fail.
+     */
+    public void forceNextLockFail() {
+        streamClient.forceNextLockFail();
+    }
+
+    /**
      * Suspends the feed.
      */
     public void suspendFeed() {

--- a/waltz-client/src/test/java/com/wepay/waltz/client/internal/InternalRpcClientTest.java
+++ b/waltz-client/src/test/java/com/wepay/waltz/client/internal/InternalRpcClientTest.java
@@ -33,7 +33,7 @@ public class InternalRpcClientTest extends InternalClientTestBase {
             TransactionBuilderImpl transactionBuilder = internalStreamClient.getTransactionBuilder(context);
             context.execute(transactionBuilder);
 
-            TransactionFuture future = internalStreamClient.append(transactionBuilder.buildRequest());
+            TransactionFuture future = internalStreamClient.append(transactionBuilder.buildRequest(), context);
 
             assertTrue(future.get());
         }

--- a/waltz-client/src/test/java/com/wepay/waltz/client/internal/InternalStreamClientTest.java
+++ b/waltz-client/src/test/java/com/wepay/waltz/client/internal/InternalStreamClientTest.java
@@ -38,7 +38,7 @@ public class InternalStreamClientTest extends InternalClientTestBase {
             TransactionBuilderImpl transactionBuilder = internalStreamClient.getTransactionBuilder(context);
             context.execute(transactionBuilder);
 
-            TransactionFuture future = internalStreamClient.append(transactionBuilder.buildRequest());
+            TransactionFuture future = internalStreamClient.append(transactionBuilder.buildRequest(), context);
 
             assertTrue(future.get());
         }
@@ -123,7 +123,7 @@ public class InternalStreamClientTest extends InternalClientTestBase {
         TransactionBuilderImpl transactionBuilder = internalStreamClient.getTransactionBuilder(context);
         context.execute(transactionBuilder);
 
-        TransactionFuture future = internalStreamClient.append(transactionBuilder.buildRequest());
+        TransactionFuture future = internalStreamClient.append(transactionBuilder.buildRequest(), context);
 
         assertTrue(future.get());
     }
@@ -149,7 +149,7 @@ public class InternalStreamClientTest extends InternalClientTestBase {
                 while (future == null) {
                     TransactionBuilderImpl transactionBuilder = internalStreamClient.getTransactionBuilder(context);
                     context.execute(transactionBuilder);
-                    future = internalStreamClient.append(transactionBuilder.buildRequest());
+                    future = internalStreamClient.append(transactionBuilder.buildRequest(), context);
                 }
 
                 futures.add(future);

--- a/waltz-client/src/test/java/com/wepay/waltz/client/internal/mock/MockDriverTest.java
+++ b/waltz-client/src/test/java/com/wepay/waltz/client/internal/mock/MockDriverTest.java
@@ -71,7 +71,7 @@ public class MockDriverTest {
             AppendRequest transaction = builder.buildRequest();
             reqIds.add(transaction.reqId);
 
-            futures.add(streamClient.append(transaction));
+            futures.add(streamClient.append(transaction, context));
 
             callbacks.awaitHighWaterMark(0, (long) i, 1000);
         }
@@ -126,7 +126,7 @@ public class MockDriverTest {
                 reqIds2.add(transaction.reqId);
             }
 
-            streamClient1.append(transaction);
+            streamClient1.append(transaction, context);
 
             callbacks1.awaitHighWaterMark(0, (long) i, 1000);
         }
@@ -152,7 +152,7 @@ public class MockDriverTest {
         AppendRequest transaction = builder.buildRequest();
         reqIds2.add(transaction.reqId);
 
-        streamClient2.append(transaction);
+        streamClient2.append(transaction, context);
         streamClient2.flushTransactions();
 
         callbacks2.awaitHighWaterMark(0, (long) numTransactions, 1000);
@@ -190,8 +190,8 @@ public class MockDriverTest {
         AppendRequest transaction1 = builder1.buildRequest();
         AppendRequest transaction2 = builder2.buildRequest();
 
-        TransactionFuture future1 = streamClient1.append(transaction1);
-        TransactionFuture future2 = streamClient2.append(transaction2);
+        TransactionFuture future1 = streamClient1.append(transaction1, context1);
+        TransactionFuture future2 = streamClient2.append(transaction2, context2);
 
         streamClient1.flushTransactions();
         streamClient2.flushTransactions();
@@ -227,7 +227,7 @@ public class MockDriverTest {
 
             AppendRequest request = builder.buildRequest();
 
-            TransactionFuture future = streamClient.append(request);
+            TransactionFuture future = streamClient.append(request, context);
             streamClient.flushTransactions();
 
             if (!future.get(1000, TimeUnit.MILLISECONDS)) {
@@ -268,7 +268,7 @@ public class MockDriverTest {
                 driver.forceNextAppendFail();
             }
 
-            TransactionFuture future = streamClient.append(transaction);
+            TransactionFuture future = streamClient.append(transaction, context);
             streamClient.flushTransactions();
 
             if (forceNextFail) {
@@ -313,7 +313,7 @@ public class MockDriverTest {
 
             AppendRequest transaction = builder.buildRequest();
 
-            futures.add(streamClient1.append(transaction));
+            futures.add(streamClient1.append(transaction, context));
         }
 
         streamClient1.flushTransactions();
@@ -341,7 +341,7 @@ public class MockDriverTest {
         context.execute(builder);
 
         AppendRequest request = builder.buildRequest();
-        streamClient2.append(request);
+        streamClient2.append(request, context);
         streamClient2.flushTransactions();
 
         callbacks2.awaitHighWaterMark(0, (long) numTransactions, 1000);

--- a/waltz-server/src/test/java/com/wepay/waltz/server/WaltzServerTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/server/WaltzServerTest.java
@@ -2,6 +2,7 @@ package com.wepay.waltz.server;
 
 import com.wepay.riff.network.Message;
 import com.wepay.waltz.client.Transaction;
+import com.wepay.waltz.client.TransactionContext;
 import com.wepay.waltz.client.WaltzClient;
 import com.wepay.waltz.common.message.AbstractMessage;
 import com.wepay.waltz.common.message.AppendRequest;
@@ -220,7 +221,7 @@ public class WaltzServerTest extends WaltzTestBase {
             AppendRequest transaction2 = client2.buildForTest(paymentContext2);
             AppendRequest transaction3 = client2.buildForTest(paymentContext3);
 
-            Future<Boolean> future1 = client1.appendForTest(transaction1);
+            Future<Boolean> future1 = client1.appendForTest(transaction1, paymentContext1);
 
             // Wait for the first append request to reach the partition
             Message msg;
@@ -230,8 +231,8 @@ public class WaltzServerTest extends WaltzTestBase {
 
             assertNotNull(msg);
 
-            Future<Boolean> future2 = client2.appendForTest(transaction2);
-            Future<Boolean> future3 = client2.appendForTest(transaction3);
+            Future<Boolean> future2 = client2.appendForTest(transaction2, paymentContext2);
+            Future<Boolean> future3 = client2.appendForTest(transaction3, paymentContext3);
 
             // Transaction1 should be success
             assertTrue(future1.get(10, TimeUnit.SECONDS));
@@ -284,7 +285,7 @@ public class WaltzServerTest extends WaltzTestBase {
             AppendRequest transaction1 = client1.buildForTest(paymentContext1);
             AppendRequest transaction2 = client2.buildForTest(paymentContext2);
 
-            Future<Boolean> future1 = client1.appendForTest(transaction1);
+            Future<Boolean> future1 = client1.appendForTest(transaction1, paymentContext1);
 
             // Wait for the first append request to reach the partition
             Message msg;
@@ -294,7 +295,7 @@ public class WaltzServerTest extends WaltzTestBase {
 
             assertNotNull(msg);
 
-            Future<Boolean> future2 = client2.appendForTest(transaction2);
+            Future<Boolean> future2 = client2.appendForTest(transaction2, paymentContext2);
 
             // Transaction1 should be success
             assertTrue(future1.get(10, TimeUnit.SECONDS));
@@ -349,7 +350,7 @@ public class WaltzServerTest extends WaltzTestBase {
             AppendRequest transaction3 = client2.buildForTest(context3);
             AppendRequest transaction4 = client2.buildForTest(context4);
 
-            Future<Boolean> future1 = client1.appendForTest(transaction1);
+            Future<Boolean> future1 = client1.appendForTest(transaction1, context1);
 
             // Wait for the first append request to reach the partition
             Message msg;
@@ -359,9 +360,9 @@ public class WaltzServerTest extends WaltzTestBase {
 
             assertNotNull(msg);
 
-            Future<Boolean> future2 = client2.appendForTest(transaction2);
-            Future<Boolean> future3 = client2.appendForTest(transaction3);
-            Future<Boolean> future4 = client2.appendForTest(transaction4);
+            Future<Boolean> future2 = client2.appendForTest(transaction2, context2);
+            Future<Boolean> future3 = client2.appendForTest(transaction3, context3);
+            Future<Boolean> future4 = client2.appendForTest(transaction4, context4);
 
             // Transaction1 should be success
             assertTrue(future1.get(10, TimeUnit.SECONDS));
@@ -528,8 +529,9 @@ public class WaltzServerTest extends WaltzTestBase {
                 String data = "transaction" + i;
                 expected.add(Arrays.asList(header, data));
                 while (true) {
-                    transaction = client.buildForTest(MockContext.builder().header(header).data(data).build());
-                    future = client.appendForTest(transaction);
+                    TransactionContext context = MockContext.builder().header(header).data(data).build();
+                    transaction = client.buildForTest(context);
+                    future = client.appendForTest(transaction, context);
 
                     // Wait for transaction to be stored and retry.
                     if (future.isDone() && !future.get()) {

--- a/waltz-server/src/test/java/com/wepay/waltz/server/WaltzTestClient.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/server/WaltzTestClient.java
@@ -37,8 +37,8 @@ class WaltzTestClient extends WaltzClient {
     }
 
     // Test only public method
-    public Future<Boolean> appendForTest(AppendRequest request) {
-        return streamClient.append(request);
+    public Future<Boolean> appendForTest(AppendRequest request, TransactionContext context) {
+        return streamClient.append(request, context);
     }
 
 }

--- a/waltz-test/src/main/java/com/wepay/waltz/test/mock/MockContext.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/mock/MockContext.java
@@ -13,6 +13,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class MockContext extends TransactionContext {
 
     public final CompletableFuture<Boolean> future = new CompletableFuture<>();
+    public final CompletableFuture<Boolean> applicationFuture = new CompletableFuture<>();
+    public final CompletableFuture<Boolean> lockFailureFuture = new CompletableFuture<>();
     public final AtomicInteger execCount = new AtomicInteger(0);
 
     private final int partitionId;
@@ -61,6 +63,16 @@ public class MockContext extends TransactionContext {
     @Override
     public void onCompletion(boolean result) {
         future.complete(result);
+    }
+
+    @Override
+    public void onApplication() {
+        applicationFuture.complete(true);
+    }
+
+    @Override
+    public void onLockFailure() {
+        lockFailureFuture.complete(true);
     }
 
     public static PartitionLocalLock makeLock(int lock) {


### PR DESCRIPTION
This PR adds two new callback methods to `TransactionContext`
1. onApplication()
2. onLockFailure()

`onApplication()` is called when the transaction generated by the transaction context is applied to the client database through `WaltzClientCallbacks.applyTransaction()`.
`onLockFailure()` is called when an append request is rejected due to a lock failure. This doesn't change the automatic retry by Waltz client. `TransactionContext` will be re-executed later. 