### PR TITLE
fix stability issue with WaltzClientTest

### DIFF
--- a/waltz-client/src/test/java/com/wepay/waltz/client/WaltzClientTest.java
+++ b/waltz-client/src/test/java/com/wepay/waltz/client/WaltzClientTest.java
@@ -116,6 +116,12 @@ public class WaltzClientTest {
             // Transaction2 should be success
             assertTrue(context2.future.get(10, TimeUnit.SECONDS));
 
+            // Wait for both transactions to be applied
+            assertTrue(context1.applicationFuture.get(10, TimeUnit.SECONDS));
+            assertTrue(context2.applicationFuture.get(10, TimeUnit.SECONDS));
+
+            // Wait for client1 to catch up
+            callbacks1.awaitHighWaterMark(0, callbacks2.getClientHighWaterMark(0), 10000);
 
             // Write Lock then Read Lock
 
@@ -138,6 +144,12 @@ public class WaltzClientTest {
 
             // Transaction2 should be failure
             assertFalse(context2.future.get(10, TimeUnit.SECONDS));
+
+            // Wait for transaction1 to be applied
+            assertTrue(context1.applicationFuture.get(10, TimeUnit.SECONDS));
+
+            // Wait for client2 to catch up
+            callbacks2.awaitHighWaterMark(0, callbacks1.getClientHighWaterMark(0), 10000);
 
             // Read Lock then Write Lock
 

--- a/waltz-storage/src/test/java/com/wepay/waltz/storage/common/message/StorageMessageCodecV0Test.java
+++ b/waltz-storage/src/test/java/com/wepay/waltz/storage/common/message/StorageMessageCodecV0Test.java
@@ -109,6 +109,7 @@ public class StorageMessageCodecV0Test {
         assertEquals(maxTransactionIdRequest1.usedByOfflineRecovery, maxTransactionIdRequest2.usedByOfflineRecovery);
     }
 
+    @SuppressWarnings("unchecked")
     private <T extends Message> T encodeThenDecode(T message) {
         ByteArrayMessageAttributeWriter writer = new ByteArrayMessageAttributeWriter();
         codec.encode(message, writer);


### PR DESCRIPTION
WaltzClientTest fails sporadically. The issue may be caused by a delay in updating a client high-water mark of a test client.