### PR TITLE
Waltz torture test with many partitions

### DIFF
--- a/waltz-test/src/main/python/waltz_ducktape/services/cli/client_cli.py
+++ b/waltz-test/src/main/python/waltz_ducktape/services/cli/client_cli.py
@@ -13,29 +13,30 @@ class ClientCli(Cli):
         """
         super(ClientCli, self).__init__(cli_config_path)
 
-    def validate_txn_cmd(self, partition_id, txn_per_client, num_clients, interval, high_watermark=None):
+    def validate_txn_cmd(self, num_active_partitions, txn_per_client, num_clients, interval, high_watermark=None):
         """
         Return validation cli command to submit and validate transactions, which
         includes validating high water mark, transaction data and optimistic lock.
 
         java com.wepay.waltz.tools.client.ClientCli \
             validate \
-            --partition <the partition id>
-            --high-watermark <current high watermark for the partition, default to -1>
-            --txn-per-client <number of transactions per client>
-            --num-clients <number of total clients>
-            --interval <average interval(millisecond) between transactions>
-            --cli-config-path <client cli config file path>
+            --num_active_partitions <number of active partitions> \
+            --txn-per-client <number of transactions per client> \
+            --num-clients <number of total clients> \
+            --interval <average interval(millisecond) between transactions> \
+            --cli-config-path <client cli config file path> \
+            --high-watermark <current high watermark for the partition, default to -1> \
+            --num-active-partitions <number of partitions to interact with>
         """
         cmd_arr = [
             "java -Dlog4j.configuration=file:/etc/waltz-client/waltz-log4j.cfg", self.java_cli_class_name(),
             "validate",
-            "--partition", partition_id,
-            "--high-watermark", high_watermark if high_watermark is not None else -1,
             "--txn-per-client", txn_per_client,
             "--num-clients", num_clients,
             "--interval", interval,
-            "--cli-config-path", self.cli_config_path
+            "--cli-config-path", self.cli_config_path,
+            "--high-watermark {}".format(high_watermark) if high_watermark is not None else "",
+            "--num-active-partitions {}".format(num_active_partitions) if num_active_partitions is not None else ""
         ]
         return self.build_cmd(cmd_arr)
 

--- a/waltz-test/src/main/python/waltz_ducktape/tests/produce_consume_validate.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/produce_consume_validate.py
@@ -183,8 +183,9 @@ class ProduceConsumeValidateTest(WaltzTest):
         """
         self.logger.info("Retrieving local low-water mark of storage {}".format(storage))
         partition_info = self.storage_cli.list_partition(storage)
-        regex = "Partition Info for id:\s*{}(.|\n)+localLowWaterMark:\s*(-?\d+)".format(partition)
-        return int(search(regex, partition_info).group(2))
+        filter_regex = "Partition Info for id:\s*{}(.|\n)+".format(partition)
+        filtered_partition_info = search(filter_regex, partition_info).group()
+        return int(search("localLowWaterMark:\s*(-?\d+)|$", filtered_partition_info).group(1))
 
     def get_storage_session_id(self, storage, partition):
         """
@@ -192,8 +193,9 @@ class ProduceConsumeValidateTest(WaltzTest):
         """
         self.logger.info("Retrieving session id of storage {}".format(storage))
         partition_info = self.storage_cli.list_partition(storage)
-        regex = "Partition Info for id:\s*{}(.|\n)+SessionId:\s*(-?\d+)".format(partition)
-        return int(search(regex, partition_info).group(2))
+        filter_regex = "Partition Info for id:\s*{}(.|\n)+".format(partition)
+        filtered_partition_info = search(filter_regex, partition_info).group()
+        return int(search("sessionId:\s*(-?\d+)|$", filtered_partition_info).group(1))
 
     def get_cluster_key(self):
         self.logger.info("Retrieving cluster key from zookeeper")

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/recovery_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/recovery_test.py
@@ -1,3 +1,4 @@
+from random import randrange
 from ducktape.mark import parametrize
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
@@ -14,28 +15,28 @@ class RecoveryTest(ProduceConsumeValidateTest):
         super(RecoveryTest, self).__init__(test_context=test_context)
 
     @cluster(nodes_spec={'storage':3, 'server':2, 'client':1})
-    @parametrize(partition=1, txn_per_client=250, num_clients=1, interval=100, timeout=240)
-    def test_recover_dirty_replica(self, partition, txn_per_client, num_clients, interval, timeout):
+    @parametrize(num_active_partitions=1, txn_per_client=250, num_clients=1, interval=100, timeout=240)
+    def test_recover_dirty_replica(self, num_active_partitions, txn_per_client, num_clients, interval, timeout):
         src_replica_idx = 0
         dst_replica_idx = 2
-        self.run_produce_consume_validate(lambda: self.recover_dirty_replica(src_replica_idx, dst_replica_idx, partition,
+        self.run_produce_consume_validate(lambda: self.recover_dirty_replica(src_replica_idx, dst_replica_idx, num_active_partitions,
                                                                              txn_per_client, num_clients, interval, timeout))
 
     @cluster(nodes_spec={'storage':3, 'server':2, 'client':1})
-    @parametrize(partition=1, txn_per_client=250, num_clients=1, interval=100, timeout=240)
-    def test_bring_replica_back_online(self, partition, txn_per_client, num_clients, interval, timeout):
+    @parametrize(num_active_partitions=1, txn_per_client=250, num_clients=1, interval=100, timeout=240)
+    def test_bring_replica_back_online(self, num_active_partitions, txn_per_client, num_clients, interval, timeout):
         offline_replica_idx = 0
 
-        self.run_produce_consume_validate(lambda: self.bring_replica_back_online(offline_replica_idx, partition, txn_per_client,
+        self.run_produce_consume_validate(lambda: self.bring_replica_back_online(offline_replica_idx, num_active_partitions, txn_per_client,
                                                                            num_clients, interval, timeout))
 
-    def recover_dirty_replica(self, src_replica_idx, dst_replica_idx, partition, txn_per_client, num_clients, interval, timeout):
+    def recover_dirty_replica(self, src_replica_idx, dst_replica_idx, num_active_partitions, txn_per_client, num_clients, interval, timeout):
         """
         A validate function to test offline recovery if a dirty replica.
 
         :param src_replica_idx: The index of source replica, where new replica recovers from
         :param dst_replica_idx: The index of destination replica
-        :param partition: The partition id to test against
+        :param num_active_partitions: Number of active partitions
         :param txn_per_client: Number of transactions per client
         :param num_clients: Number of total clients
         :param interval: Average interval(millisecond) between transactions
@@ -49,9 +50,10 @@ class RecoveryTest(ProduceConsumeValidateTest):
         dst_node = self.waltz_storage.nodes[dst_replica_idx]
         dst_node_hostname = dst_node.account.ssh_hostname
         dst_storage = self.get_host(dst_node_hostname, admin_port)
+        partition = randrange(num_active_partitions)
 
         # Step 1: Submit transactions to all replicas.
-        cmd = self.client_cli.validate_txn_cmd(partition, txn_per_client, num_clients, interval)
+        cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
         self.verifiable_client.start(cmd)
         wait_until(lambda: self.is_max_transaction_id_updated(src_storage, port, partition, -1), timeout_sec=timeout)
 
@@ -78,12 +80,12 @@ class RecoveryTest(ProduceConsumeValidateTest):
         wait_until(lambda: self.verifiable_client.task_complete() == True, timeout_sec=timeout,
                    err_msg="verifiable_client failed to complete task in %d seconds." % timeout)
 
-    def bring_replica_back_online(self, offline_replica_idx, partition, txn_per_client, num_clients, interval, timeout):
+    def bring_replica_back_online(self, offline_replica_idx, num_active_partitions, txn_per_client, num_clients, interval, timeout):
         """
         A validate function to test if a replica can successfully recover when brought back online.
 
         :param offline_replica_idx: The index of offline replica
-        :param partition: The partition id to test against
+        :param num_active_partitions: Number of active partitions
         :param txn_per_client: Number of transactions per client
         :param num_clients: Number of total clients
         :param interval: Average interval(millisecond) between transactions
@@ -92,9 +94,10 @@ class RecoveryTest(ProduceConsumeValidateTest):
         admin_port = self.waltz_storage.admin_port
         node = self.waltz_storage.nodes[offline_replica_idx]
         hostname = node.account.ssh_hostname
+        partition = randrange(num_active_partitions)
 
         # Step 1: Produce a number of transactions.
-        cmd = self.client_cli.validate_txn_cmd(partition, txn_per_client, num_clients, interval, -1)
+        cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval, -1)
         self.verifiable_client.start(cmd)
 
         # Step 2: Mark storage node 0 offline for reads and writes.

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/smoke_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/smoke_test.py
@@ -1,3 +1,4 @@
+from random import randrange
 from ducktape.mark.resource import cluster
 from ducktape.mark import parametrize
 from waltz_ducktape.tests.produce_consume_validate import ProduceConsumeValidateTest
@@ -14,35 +15,38 @@ class SmokeTest(ProduceConsumeValidateTest):
         super(SmokeTest, self).__init__(test_context=test_context)
 
     @cluster(nodes_spec={'storage':3, 'server':2, 'client':1})
-    @parametrize(partition=1, txn_per_client=500, num_clients=10, interval=120, timeout=240)
-    def test_produce_consume_no_torture(self, partition, txn_per_client, num_clients, interval, timeout):
-        validation_cmd = self.client_cli.validate_txn_cmd(partition, txn_per_client, num_clients, interval)
+    @parametrize(num_active_partitions=1, txn_per_client=500, num_clients=10, interval=120, timeout=240)
+    @parametrize(num_active_partitions=4, txn_per_client=500, num_clients=10, interval=120, timeout=240)
+    def test_produce_consume_no_torture(self, num_active_partitions, txn_per_client, num_clients, interval, timeout):
+        validation_cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
         self.run_produce_consume_validate(lambda: self.simple_validation_func(validation_cmd, timeout))
 
     @cluster(nodes_spec={'storage':3, 'server':2, 'client':1})
-    @parametrize(partition=0, txn_per_client=500, num_clients=10, interval=120, timeout=480)
-    def test_produce_consume_while_bouncing_storage_nodes(self, partition, txn_per_client, num_clients, interval, timeout):
-        validation_cmd = self.client_cli.validate_txn_cmd(partition, txn_per_client, num_clients, interval)
+    @parametrize(num_active_partitions=1, txn_per_client=500, num_clients=10, interval=120, timeout=480)
+    @parametrize(num_active_partitions=4, txn_per_client=500, num_clients=10, interval=120, timeout=480)
+    def test_produce_consume_while_bouncing_storage_nodes(self, num_active_partitions, txn_per_client, num_clients, interval, timeout):
+        validation_cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
         validation_result = self.run_produce_consume_validate(lambda: self.simple_validation_func(validation_cmd, timeout),
                                                               lambda: self._bounce_storage_nodes(3))
         assert "exception" not in validation_result.lower(), "Test failed with exception:\n{}".format(validation_result)
 
     @cluster(nodes_spec={'storage':3, 'server':2, 'client':1})
-    @parametrize(partition=0, txn_per_client=500, num_clients=2, interval=120, timeout=240)
-    def test_produce_consume_while_killing_a_server_node(self, partition, txn_per_client, num_clients, interval, timeout):
-        validation_cmd = self.client_cli.validate_txn_cmd(partition, txn_per_client, num_clients, interval)
+    @parametrize(num_active_partitions=1, txn_per_client=500, num_clients=2, interval=120, timeout=240)
+    @parametrize(num_active_partitions=4, txn_per_client=500, num_clients=2, interval=120, timeout=240)
+    def test_produce_consume_while_killing_a_server_node(self, num_active_partitions, txn_per_client, num_clients, interval, timeout):
+        validation_cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
         self.run_produce_consume_validate(lambda: self.simple_validation_func(validation_cmd, timeout),
-                                          lambda: self._kill_a_server_node(partition))
+                                          lambda: self._kill_a_server_node(num_active_partitions))
 
     def _bounce_storage_nodes(self, interval):
         storage_node_bounce_scheduler = NodeBounceScheduler(service=self.waltz_storage, interval=interval,
                                                             stop_condition=lambda: self.verifiable_client.task_complete())
         storage_node_bounce_scheduler.start()
 
-    def _kill_a_server_node(self, partition):
-        node_idx = self.get_server_node_idx(partition)
+    def _kill_a_server_node(self, num_active_partitions):
+        node_idx = self.get_server_node_idx(randrange(num_active_partitions))
         cmd_list = [{"action": NodeBounceScheduler.IDLE},
-                              {"action": NodeBounceScheduler.STOP_A_NODE, "node": node_idx}]
+                    {"action": NodeBounceScheduler.STOP_A_NODE, "node": node_idx}]
         server_node_bounce_scheduler = NodeBounceScheduler(service=self.waltz_server, interval=3,
                                                            stop_condition=lambda: self.verifiable_client.task_complete(),
                                                            iterable_cmd_list=iter(cmd_list))

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/client/ClientCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/client/ClientCli.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -82,6 +83,10 @@ public final class ClientCli extends SubcommandCli {
         private static final String LOCK_NAME = "validate-lock";
         private static final int LOCK_ID = 0;
         private static final int LAMBDA = 1;
+        private static final int DEFAULT_HIGH_WATERMARK = -1;
+        private static final int DEFAULT_NUMBER_ACTIVE_PARTITIONS = 1;
+        private static final Random RANDOM = new Random();
+
         private static final List<PartitionLocalLock> LOCKS = Collections.singletonList(new PartitionLocalLock(LOCK_NAME, LOCK_ID));
 
         private final Map<Integer, ConcurrentHashMap<Integer, Long>> clientHighWaterMarkMap;
@@ -99,22 +104,12 @@ public final class ClientCli extends SubcommandCli {
 
         @Override
         protected void configureOptions(Options options) {
-            Option partitionOption = Option.builder("p")
-                    .longOpt("partition")
-                    .desc("Specify partition Id for transactions")
-                    .hasArg()
-                    .build();
-            Option highWatermarkOption = Option.builder("h")
-                    .longOpt("high-watermark")
-                    .desc("Specify current high watermark for the partition; default to -1")
-                    .hasArg()
-                    .build();
             Option txnPerClientOption = Option.builder("tpc")
                     .longOpt("txn-per-client")
                     .desc("Specify number of transactions per client")
                     .hasArg()
                     .build();
-            Option numClientOption = Option.builder("nc")
+            Option numClientsOption = Option.builder("nc")
                     .longOpt("num-clients")
                     .desc("Specify number of total clients")
                     .hasArg()
@@ -129,33 +124,43 @@ public final class ClientCli extends SubcommandCli {
                     .desc("Specify client cli config file path")
                     .hasArg()
                     .build();
+            Option highWatermarkOption = Option.builder("h")
+                    .longOpt("high-watermark")
+                    .desc("Specify current high watermark for the partition")
+                    .hasArg()
+                    .build();
+            Option numActivePartitionOption = Option.builder("ap")
+                    .longOpt("num-active-partitions")
+                    .desc(String.format("Specify number of partitions to interact with. e.g. if set to 3, transactions will"
+                            + "be evenly distributed among partition 0, 1 and 2. Defualt to %d", DEFAULT_NUMBER_ACTIVE_PARTITIONS))
+                    .hasArg()
+                    .build();
 
-            partitionOption.setRequired(true);
-            highWatermarkOption.setRequired(false);
             txnPerClientOption.setRequired(true);
-            numClientOption.setRequired(true);
+            numClientsOption.setRequired(true);
             intervalOption.setRequired(true);
             cfgPathOption.setRequired(true);
+            highWatermarkOption.setRequired(false);
+            numActivePartitionOption.setRequired(false);
 
-            options.addOption(partitionOption);
-            options.addOption(highWatermarkOption);
             options.addOption(txnPerClientOption);
-            options.addOption(numClientOption);
+            options.addOption(numClientsOption);
             options.addOption(intervalOption);
             options.addOption(cfgPathOption);
+            options.addOption(highWatermarkOption);
+            options.addOption(numActivePartitionOption);
         }
 
         @Override
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
             try {
-                int partitionId = Integer.parseInt(cmd.getOptionValue("partition"));
-                int highWaterMark = cmd.hasOption("high-watermark") ? Integer.parseInt(cmd.getOptionValue("high-watermark")) : -1;
+                // check required arguments
                 int txnPerClient = Integer.parseInt(cmd.getOptionValue("txn-per-client"));
                 if (txnPerClient < 0) {
                     throw new IllegalArgumentException("Found negative: txn-per-client must be greater or equals to 0");
                 }
-                int numClient = Integer.parseInt(cmd.getOptionValue("num-clients"));
-                if (numClient < 0) {
+                int numClients = Integer.parseInt(cmd.getOptionValue("num-clients"));
+                if (numClients < 0) {
                     throw new IllegalArgumentException("Found negative: num-clients must be greater or equals to 0");
                 }
                 int avgInterval = Integer.parseInt(cmd.getOptionValue("interval"));
@@ -165,18 +170,28 @@ public final class ClientCli extends SubcommandCli {
                 String configFilePath = cmd.getOptionValue("cli-config-path");
                 WaltzClientConfig waltzClientConfig = getWaltzClientConfig(configFilePath);
 
-                int numTxnToSubmit = txnPerClient * numClient;
+                // check optional argument
+                int highWaterMark = cmd.hasOption("high-watermark") ? Integer.parseInt(cmd.getOptionValue("high-watermark")) : DEFAULT_HIGH_WATERMARK;
+                if (highWaterMark < -1) {
+                    throw new IllegalArgumentException("high-watermark must be greater or equals to -1");
+                }
+                int numActivePartitions = cmd.hasOption("num-active-partitions") ? Integer.parseInt(cmd.getOptionValue("num-active-partitions")) : DEFAULT_NUMBER_ACTIVE_PARTITIONS;
+                if (numActivePartitions < 1) {
+                    throw new IllegalArgumentException("num-active-partitions must be greater or equals to 1");
+                }
+
+                int numTxnToSubmit = txnPerClient * numClients;
                 int numTxnAppended = highWaterMark + 1;
                 // each client will receive callback of all transactions
-                int expectNumProducerCallbacks = (numTxnAppended + numTxnToSubmit) * numClient;
+                int expectNumProducerCallbacks = (numTxnAppended + numTxnToSubmit) * numClients;
                 int expectNumConsumerCallbacks = (numTxnAppended + numTxnToSubmit) * 1;
-                allProducerReady = new CountDownLatch(numClient);
+                allProducerReady = new CountDownLatch(numClients);
                 allProducerTxnCallbackReceived = new CountDownLatch(expectNumProducerCallbacks);
                 allConsumerTxnCallbackReceived = new CountDownLatch(expectNumConsumerCallbacks);
 
-                produceTransactions(partitionId, numClient, txnPerClient, avgInterval, waltzClientConfig);
+                produceTransactions(numActivePartitions, numClients, txnPerClient, avgInterval, waltzClientConfig);
 
-                consumeAndValidate(partitionId, waltzClientConfig);
+                consumeAndValidate(waltzClientConfig);
 
                 checkUncaughtExceptions();
             } catch (Exception e) {
@@ -216,17 +231,17 @@ public final class ClientCli extends SubcommandCli {
 
         /**
          * Produce specific number of transactions with each client with intervals.
-         * @param partitionId the partition for transactions to produce
-         * @param numClient number of clients
+         * @param numActivePartitions number of active partitions
+         * @param numClients number of clients
          * @param txnPerClient number of transactions to submit for each clients
          * @param avgInterval average submission interval
          * @param config WaltzClientConfig
          * @throws Exception
          */
-        private void produceTransactions(int partitionId, int numClient, int txnPerClient, int avgInterval,
+        private void produceTransactions(int numActivePartitions, int numClients, int txnPerClient, int avgInterval,
                                          WaltzClientConfig config) throws Exception {
-            ExecutorService executor = Executors.newFixedThreadPool(numClient);
-            for (int i = 0; i < numClient; i++) {
+            ExecutorService executor = Executors.newFixedThreadPool(numClients);
+            for (int i = 0; i < numClients; i++) {
                 ProducerTxnCallbacks producerTnxCallback = new ProducerTxnCallbacks();
                 WaltzClient producer = new WaltzClient(producerTnxCallback, config);
 
@@ -236,7 +251,7 @@ public final class ClientCli extends SubcommandCli {
                 clientHighWaterMarkMap.putIfAbsent(producer.clientId(), new ConcurrentHashMap<>());
 
                 // all thread start, but transactions won't be fired until all clients are ready
-                executor.execute(new ProducerThread(partitionId, txnPerClient, avgInterval, producer));
+                executor.execute(new ProducerThread(numActivePartitions, txnPerClient, avgInterval, producer));
                 allProducerReady.countDown();
             }
 
@@ -245,14 +260,13 @@ public final class ClientCli extends SubcommandCli {
         }
 
         /**
-         * Consume all transactions, and validate callbacks of specific partition.
-         * @param partitionId the partition to validate
+         * Consume all transactions, and validate callbacks of all partitions.
          * @param config WaltzClientConfig
          * @throws Exception
          */
-        private void consumeAndValidate(int partitionId, WaltzClientConfig config) throws Exception {
+        private void consumeAndValidate(WaltzClientConfig config) throws Exception {
             ExecutorService executor = Executors.newFixedThreadPool(1);
-            ConsumerTxnCallbacks consumerTxnCallback = new ConsumerTxnCallbacks(partitionId);
+            ConsumerTxnCallbacks consumerTxnCallback = new ConsumerTxnCallbacks();
             WaltzClient consumer = new WaltzClient(consumerTxnCallback, config);
 
             // set consumerTxnCallback.clientId, so that will only update
@@ -267,16 +281,17 @@ public final class ClientCli extends SubcommandCli {
 
         /**
          * This class implements {@link Runnable}, which waits for all clients get ready, iteratively fires all
-         * transactions with an exponential distributed interval.
+         * transactions with an exponential distributed interval. Transactions will be evenly distributed among
+         * all active partitions.
          */
         private final class ProducerThread implements Runnable {
-            private int partitionId;
+            private int numActivePartitions;
             private int txnPerThread;
             private int avgInterval;
             private WaltzClient client;
 
-            ProducerThread(int partitionId, int txnPerThread, int avgInterval, WaltzClient client) {
-                this.partitionId = partitionId;
+            ProducerThread(int numActivePartitions, int txnPerThread, int avgInterval, WaltzClient client) {
+                this.numActivePartitions = numActivePartitions;
                 this.txnPerThread = txnPerThread;
                 this.avgInterval = avgInterval;
                 this.client = client;
@@ -289,6 +304,7 @@ public final class ClientCli extends SubcommandCli {
 
                     // fire transactions
                     for (int j = 0; j < txnPerThread; j++) {
+                        int partitionId = RANDOM.nextInt(numActivePartitions);
                         client.submit(new HighWaterMarkTxnContext(partitionId, client.clientId()));
 
                         // By adjusting the distribution parameter of the random sleep,
@@ -377,39 +393,35 @@ public final class ClientCli extends SubcommandCli {
          */
         private final class ConsumerTxnCallbacks implements WaltzClientCallbacks {
             private static final int DEFAULT_CLIENT_ID = -1;
-            private final int partitionToValidate;
 
             // clientId will be reset with consumer.clientId()
             private int clientId = DEFAULT_CLIENT_ID;
-            private long curHighWaterMark;
 
-            private ConsumerTxnCallbacks(int partitionToValidate) {
-                this.partitionToValidate = partitionToValidate;
-                curHighWaterMark = -1;
+            private ConsumerTxnCallbacks() {
             }
 
             @Override
             public long getClientHighWaterMark(int partitionId) {
                 if (clientId == DEFAULT_CLIENT_ID) {
-                    return -1;
+                    return -1L;
                 }
                 return clientHighWaterMarkMap.get(clientId).getOrDefault(partitionId, -1L);
             }
 
             @Override
             public void applyTransaction(Transaction transaction) {
-                // update client side high water mark
-                if (transaction.reqId.partitionId() == partitionToValidate) {
-                    if (transaction.transactionId - 1 == curHighWaterMark) {
-                        if (transaction.getTransactionData(HighWaterMarkSerializer.INSTANCE).longValue() != transaction.transactionId) {
-                            throw new SubCommandFailedException("optimistic locking validation failed");
-                        }
-                        curHighWaterMark = transaction.transactionId;
-                        allConsumerTxnCallbackReceived.countDown();
-                    } else {
-                        throw new SubCommandFailedException(String.format("expect callback transaction id to be %s, but got %s",
-                                                                          curHighWaterMark + 1, transaction.transactionId));
+                int partitionId = transaction.reqId.partitionId();
+                long curHighWaterMark = clientHighWaterMarkMap.get(clientId).getOrDefault(partitionId, -1L);
+                if (transaction.transactionId == curHighWaterMark + 1) {
+                    if (transaction.getTransactionData(HighWaterMarkSerializer.INSTANCE).longValue() != transaction.transactionId) {
+                        throw new SubCommandFailedException("optimistic locking validation failed");
                     }
+                    // update client side high water mark
+                    clientHighWaterMarkMap.get(clientId).put(partitionId, transaction.transactionId);
+                    allConsumerTxnCallbackReceived.countDown();
+                } else {
+                    throw new SubCommandFailedException(String.format("expect callback transaction id to be %s, but got %s",
+                                                                      curHighWaterMark + 1, transaction.transactionId));
                 }
             }
 

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/performance/PerformanceCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/performance/PerformanceCli.java
@@ -36,6 +36,7 @@ public final class PerformanceCli extends SubcommandCli {
 
     private static final int MILLISECONDS_IN_SECOND = 1000;
     private static final int BYTES_IN_MEGABYTE = 1024 * 1024;
+    private static final int DEFAULT_NUMBER_ACTIVE_PARTITIONS = 1;
     private static final Random RANDOM = new Random();
 
     private PerformanceCli(String[] args, boolean useByTest) {
@@ -100,14 +101,14 @@ public final class PerformanceCli extends SubcommandCli {
                     .build();
             Option numActivePartitionOption = Option.builder("ap")
                     .longOpt("num-active-partitions")
-                    .desc("Specify number of partitions to interact with. For example, if set to 3, transactions will be evenly"
-                            + "distributed among partition 0, 1 and 2. Default to 1")
+                    .desc(String.format("Specify number of partitions to interact with. For example, if set to 3, transactions will be"
+                            + "evenly distributed among partition 0, 1 and 2. Default to %d", DEFAULT_NUMBER_ACTIVE_PARTITIONS))
                     .hasArg()
                     .build();
             Option lockPoolSizeOption = Option.builder("l")
                     .longOpt("lock-pool-size")
-                    .desc("Specify size of lock pool. Greater the size, less likely transactions get rejected."
-                            + "No transaction gets rejected when size is 0. Default to 0")
+                    .desc(String.format("Specify size of lock pool. Greater the size, less likely transactions get rejected."
+                            + "No transaction gets rejected when size is 0. Default to %d", DEFAULT_LOCK_POOL_SIZE))
                     .hasArg()
                     .build();
 
@@ -155,7 +156,7 @@ public final class PerformanceCli extends SubcommandCli {
                 if (cmd.hasOption("num-active-partitions")) {
                     numActivePartitions = Integer.parseInt(cmd.getOptionValue("num-active-partitions"));
                     if (numActivePartitions < 1) {
-                        throw new IllegalArgumentException("Number of active partitions must be greater of equals to 1");
+                        throw new IllegalArgumentException("Number of active partitions must be greater or equals to 1");
                     }
                 }
                 if (cmd.hasOption("lock-pool-size")) {
@@ -382,8 +383,8 @@ public final class PerformanceCli extends SubcommandCli {
                     .build();
             Option numActivePartitionOption = Option.builder("ap")
                     .longOpt("num-active-partitions")
-                    .desc("Specify number of active partitions to interact with. For example, if set to 3, transactions will be evenly"
-                            + "distributed among partition 0, 1 and 2. Default to 1")
+                    .desc(String.format("Specify number of active partitions to interact with. For example, if set to 3, transactions will be evenly"
+                            + "distributed among partition 0, 1 and 2. Default to %d", DEFAULT_NUMBER_ACTIVE_PARTITIONS))
                     .hasArg()
                     .build();
             txnSizeOption.setRequired(true);
@@ -610,8 +611,6 @@ public final class PerformanceCli extends SubcommandCli {
 
     private abstract static class PerformanceBase extends Cli {
 
-        private static final int DEFAULT_NUMBER_ACTIVE_PARTITIONS = 1;
-
         protected final AtomicLong startTime;
 
         protected int numActivePartitions;
@@ -622,7 +621,6 @@ public final class PerformanceCli extends SubcommandCli {
 
         private PerformanceBase(String[] args) {
             super(args);
-            numActivePartitions = DEFAULT_NUMBER_ACTIVE_PARTITIONS;
             startTime = new AtomicLong(0);
         }
 

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
@@ -164,8 +164,8 @@ public final class StorageCli extends SubcommandCli {
                 int partitionId = entry.getKey();
                 PartitionInfoSnapshot snapshot = entry.getValue();
                 sb.append(String.format("Partition Info for id: %d%n", partitionId));
-                sb.append(String.format("\t SessionId: %d%n", snapshot.sessionId));
-                sb.append(String.format("\t LowWaterMark: %d%n", snapshot.lowWaterMark));
+                sb.append(String.format("\t sessionId: %d%n", snapshot.sessionId));
+                sb.append(String.format("\t lowWaterMark: %d%n", snapshot.lowWaterMark));
                 sb.append(String.format("\t localLowWaterMark: %d%n", snapshot.localLowWaterMark));
                 sb.append(String.format("\t isAssigned: %b%n", snapshot.isAssigned));
                 sb.append(String.format("\t isAvailable: %b%n", snapshot.isAvailable));
@@ -604,7 +604,7 @@ public final class StorageCli extends SubcommandCli {
                                  Integer.parseInt(destinationStoragePort), Integer.parseInt(partitionId), Integer.parseInt(batchSize), cliConfigPath,
                                  sourceSslConfigPath, destinationSslConfigPath);
            } catch (Exception e) {
-                throw new SubCommandFailedException(String.format("Partition %s not recover. %n%s", partitionId, e.getMessage()));
+                throw new SubCommandFailedException(String.format("Partition %s failed to recover. %n%s", partitionId, e.getMessage()));
             }
         }
 


### PR DESCRIPTION
1) Added "--num-active-partitions" option to `ClientCli.Validate` cmd; default to 1
2) If more than one active partitions, transactions will be evenly distributed
3) Check serializability each transaction callback with a map of <client_id, <partition_id, high_watermark>>
4) Wait until receive all transaction callback received (from different partitions) before mark success
5) Tested locally