### PR TITLE
[DI-2654] List partition without storage specified

### DIFF
--- a/waltz-test/src/main/java/com/wepay/waltz/test/smoketest/SmokeTest.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/smoketest/SmokeTest.java
@@ -214,7 +214,7 @@ public class SmokeTest {
         runner.awaitStart();
 
         // Assign all partitions to this storage.
-        helper.setWaltzStorageAssignment(adminPort, true);
+        helper.setWaltzStorageAssignmentWithPort(adminPort, true);
 
         runner.stop();
 

--- a/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
@@ -112,11 +112,6 @@ public class IntegrationTestHelper {
 
         PortFinder portFinder = new PortFinder();
         this.zkPort = portFinder.getPort();
-        for (int i = 0; i < numStorages; i++) {
-            this.storagePorts.add(portFinder.getPort());
-            this.storageAdminPorts.add(portFinder.getPort());
-            this.storageJettyPorts.add(portFinder.getPort());
-        }
         this.serverPort = portFinder.getPort();
         this.serverJettyPort = portFinder.getPort();
 
@@ -125,6 +120,9 @@ public class IntegrationTestHelper {
         this.storageGroupMap = new HashMap<String, Integer>();
         this.storageConnectionMap = new HashMap<String, Integer>();
         for (int i = 0; i < numStorages; i++) {
+            this.storagePorts.add(portFinder.getPort());
+            this.storageAdminPorts.add(portFinder.getPort());
+            this.storageJettyPorts.add(portFinder.getPort());
             this.storageGroupMap.put(host + ":" + storagePorts.get(i), STORAGE_GROUP_ID);
             this.storageConnectionMap.put(host + ":" + storagePorts.get(i), storageAdminPorts.get(i));
         }
@@ -312,7 +310,7 @@ public class IntegrationTestHelper {
      * @throws Exception
      */
     public StorageAdminClient getStorageAdminClient() throws Exception {
-        return getStorageAdminClientWithPort(0);
+        return getStorageAdminClientWithIndex(0);
     }
 
     /**
@@ -320,11 +318,12 @@ public class IntegrationTestHelper {
      * The Storage client requires ZooKeeperServer to be running, meaning you must call startZooKeeperServer()
      * before calling this method.
      *
+     * @param adminPortIndex index of the admin port from storageAdminPorts
      * @return StorageAdminClient instance
      * @throws Exception
      */
-    public StorageAdminClient getStorageAdminClient(int adminPortIndex) throws Exception {
-        return getStorageAdminClientWithPort(storageAdminPorts.get(adminPortIndex));
+    public StorageAdminClient getStorageAdminClientWithIndex(int adminPortIndex) throws Exception {
+        return getStorageAdminClientWithAdminPort(storageAdminPorts.get(adminPortIndex));
     }
 
     /**
@@ -332,10 +331,11 @@ public class IntegrationTestHelper {
      * The Storage client requires ZooKeeperServer to be running, meaning you must call startZooKeeperServer()
      * before calling this method.
      *
+     * @param adminPort Admin port for the StorageAdminClient
      * @return StorageAdminClient instance
      * @throws Exception
      */
-    public StorageAdminClient getStorageAdminClientWithPort(int adminPort) throws Exception {
+    public StorageAdminClient getStorageAdminClientWithAdminPort(int adminPort) throws Exception {
         synchronized (storageAdminClients) {
             StorageAdminClient storageAdminClient = storageAdminClients.get(adminPort);
             if (storageAdminClient == null) {
@@ -355,13 +355,13 @@ public class IntegrationTestHelper {
      * This method assigns/unassigns all partitions to the storage node via the Storage admin client
      */
     public void setWaltzStorageAssignment(boolean isAssigned) throws Exception {
-        setWaltzStorageAssignment(0, isAssigned);
+        setWaltzStorageAssignmentWithIndex(0, isAssigned);
     }
 
     /**
      * This method assigns/unassigns all partitions to the storage node via the Storage admin client
      */
-    public void setWaltzStorageAssignment(int portIndex, boolean isAssigned) throws Exception {
+    public void setWaltzStorageAssignmentWithIndex(int portIndex, boolean isAssigned) throws Exception {
         setWaltzStorageAssignmentWithPort(storageAdminPorts.get(portIndex), isAssigned);
     }
 
@@ -369,7 +369,7 @@ public class IntegrationTestHelper {
      * This method assigns/unassigns all partitions to the storage node via the Storage admin client
      */
     public void setWaltzStorageAssignmentWithPort(int adminPort, boolean isAssigned) throws Exception {
-        StorageAdminClient storageAdminClient = getStorageAdminClientWithPort(adminPort);
+        StorageAdminClient storageAdminClient = getStorageAdminClientWithAdminPort(adminPort);
 
         List<Future<?>> futures = new ArrayList<>(numPartitions);
         for (int i = 0; i < numPartitions; i++) {

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -107,8 +108,7 @@ public final class StorageCli extends SubcommandCli {
                     if (hostAndPortArray.length != 2) {
                         throw new IllegalArgumentException("Http must be in format of host:admin_port");
                     }
-                    hostsAndPorts = new ArrayList<>();
-                    hostsAndPorts.add(hostAndPortArray);
+                    hostsAndPorts = Collections.singletonList(hostAndPortArray);
                 } catch (IllegalArgumentException e) {
                     throw new SubCommandFailedException(String.format("Cannot fetch partition ownership for %s:%n%s",
                             providedHostAndPort, e.getMessage()));

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
@@ -123,7 +123,7 @@ public final class StorageCli extends SubcommandCli {
 
                     String metricsJson = getMetricsJson(storageHost, Integer.parseInt(storagePort), cliConfigPath);
                     Map<Integer, PartitionInfoSnapshot> partitionInfo = getPartitionInfo(metricsJson);
-                    partitionInfoStringBuilder.append(getListPartitionInfo(partitionInfo, storageHost, storagePort));
+                    partitionInfoStringBuilder.append(formatPartitionInfo(partitionInfo, storageHost, storagePort));
                     partitionInfoStringBuilder.append("\n");
                 } catch (Exception e) {
                     throw new SubCommandFailedException(String.format("Cannot fetch partition ownership for %s:%s:%n%s",
@@ -206,7 +206,7 @@ public final class StorageCli extends SubcommandCli {
             return partitionInfo;
         }
 
-        private StringBuilder getListPartitionInfo(Map<Integer, PartitionInfoSnapshot> partitionInfo, String storageHost, String storagePort) {
+        private StringBuilder formatPartitionInfo(Map<Integer, PartitionInfoSnapshot> partitionInfo, String storageHost, String storagePort) {
             StringBuilder sb = new StringBuilder();
             // display partition info
             for (Map.Entry<Integer, PartitionInfoSnapshot> entry: partitionInfo.entrySet()) {
@@ -223,7 +223,7 @@ public final class StorageCli extends SubcommandCli {
         }
 
         private void listPartitionInfo(Map<Integer, PartitionInfoSnapshot> partitionInfo, String storageHost, String storagePort) {
-            System.out.println(getListPartitionInfo(partitionInfo, storageHost, storagePort));
+            System.out.println(formatPartitionInfo(partitionInfo, storageHost, storagePort));
         }
 
         @Override

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
@@ -109,8 +109,7 @@ public final class StorageCli extends SubcommandCli {
                     }
                     hostsAndPorts = new ArrayList<>();
                     hostsAndPorts.add(hostAndPortArray);
-                }
-                catch (IllegalArgumentException e) {
+                } catch (IllegalArgumentException e) {
                     throw new SubCommandFailedException(String.format("Cannot fetch partition ownership for %s:%n%s",
                             providedHostAndPort, e.getMessage()));
                 }

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
@@ -37,6 +37,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.List;
+import java.util.ArrayList;
 
 /**
  * StorageCli is a tool for interacting with Waltz Storage.
@@ -82,7 +84,7 @@ public final class StorageCli extends SubcommandCli {
                     .desc("Specify the cli config file path required for zooKeeper connection string, zooKeeper root path and SSL config")
                     .hasArg()
                     .build();
-            storageOption.setRequired(true);
+            storageOption.setRequired(false);
             cliCfgOption.setRequired(true);
             options.addOption(storageOption);
             options.addOption(cliCfgOption);
@@ -90,22 +92,71 @@ public final class StorageCli extends SubcommandCli {
 
         @Override
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
-            String hostAndPort = cmd.getOptionValue("storage");
             String cliConfigPath = cmd.getOptionValue("cli-config-path");
+            String providedHostAndPort = cmd.getOptionValue("storage");
+            List<String[]> hostsAndPorts;
+            if (providedHostAndPort == null) {
+                try {
+                    hostsAndPorts = getAllHostsAndPorts(cliConfigPath);
+                } catch (Exception e) {
+                    throw new SubCommandFailedException("Cannot obtain zookeeper connections");
+                }
+            } else {
+                try {
+                    String[] hostAndPortArray = providedHostAndPort.split(":");
+                    if (hostAndPortArray.length != 2) {
+                        throw new IllegalArgumentException("Http must be in format of host:admin_port");
+                    }
+                    hostsAndPorts = new ArrayList<>();
+                    hostsAndPorts.add(hostAndPortArray);
+                }
+                catch (IllegalArgumentException e) {
+                    throw new SubCommandFailedException(String.format("Cannot fetch partition ownership for %s:%n%s",
+                            providedHostAndPort, e.getMessage()));
+                }
+            }
+
+            StringBuilder partitionInfoStringBuilder = new StringBuilder();
+            for (String[] hostAndPortArray : hostsAndPorts) {
+                try {
+                    String storageHost = hostAndPortArray[0];
+                    String storagePort = hostAndPortArray[1];
+
+                    String metricsJson = getMetricsJson(storageHost, Integer.parseInt(storagePort), cliConfigPath);
+                    Map<Integer, PartitionInfoSnapshot> partitionInfo = getPartitionInfo(metricsJson);
+                    partitionInfoStringBuilder.append(getListPartitionInfo(partitionInfo, storageHost, storagePort));
+                    partitionInfoStringBuilder.append("\n");
+                } catch (Exception e) {
+                    throw new SubCommandFailedException(String.format("Cannot fetch partition ownership for %s:%s:%n%s",
+                            hostAndPortArray[0], hostAndPortArray[1], e.getMessage()));
+                }
+            }
+            System.out.println(partitionInfoStringBuilder.toString());
+        }
+
+        private List<String[]> getAllHostsAndPorts(String cliConfigPath) throws Exception {
+            CliConfig cliConfig = CliConfig.parseCliConfigFile(cliConfigPath);
+            ZooKeeperClient zkClient = null;
 
             try {
-                String[] hostAndPortArray = hostAndPort.split(":");
-                if (hostAndPortArray.length != 2) {
-                    throw new IllegalArgumentException("Http must be in format of host:admin_port");
-                }
-                String storageHost = hostAndPortArray[0];
-                String storagePort = hostAndPortArray[1];
+                String zkConnectString = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
+                int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+                String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
+                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout);
 
-                String metricsJson = getMetricsJson(storageHost, Integer.parseInt(storagePort), cliConfigPath);
-                Map<Integer, PartitionInfoSnapshot> partitionInfo = getPartitionInfo(metricsJson);
-                listPartitionInfo(partitionInfo);
-            } catch (Exception e) {
-                throw new SubCommandFailedException(String.format("Cannot fetch partition ownership for %s:%n%s", hostAndPort, e.getMessage()));
+                StoreMetadata storeMetadata = new StoreMetadata(zkClient, new ZNode(zkRoot + '/' + StoreMetadata.STORE_ZNODE_NAME));
+                ConnectionMetadata md = storeMetadata.getConnectionMetadata();
+                Map<String, Integer> cons = md.connections;
+
+                List<String[]> hostsAndPorts = new ArrayList<>();
+                for (Map.Entry<String, Integer> con : cons.entrySet()) {
+                    hostsAndPorts.add(new String[]{con.getKey().split(":")[0], con.getValue().toString()});
+                }
+                return hostsAndPorts;
+            } finally {
+                if (zkClient != null) {
+                    zkClient.close();
+                }
             }
         }
 
@@ -156,21 +207,24 @@ public final class StorageCli extends SubcommandCli {
             return partitionInfo;
         }
 
-        private void listPartitionInfo(Map<Integer, PartitionInfoSnapshot> partitionInfo) {
+        private StringBuilder getListPartitionInfo(Map<Integer, PartitionInfoSnapshot> partitionInfo, String storageHost, String storagePort) {
             StringBuilder sb = new StringBuilder();
-
             // display partition info
             for (Map.Entry<Integer, PartitionInfoSnapshot> entry: partitionInfo.entrySet()) {
                 int partitionId = entry.getKey();
                 PartitionInfoSnapshot snapshot = entry.getValue();
-                sb.append(String.format("Partition Info for id: %d%n", partitionId));
+                sb.append(String.format("Partition Info for id: %d at %s:%s%n", partitionId, storageHost, storagePort));
                 sb.append(String.format("\t sessionId: %d%n", snapshot.sessionId));
                 sb.append(String.format("\t lowWaterMark: %d%n", snapshot.lowWaterMark));
                 sb.append(String.format("\t localLowWaterMark: %d%n", snapshot.localLowWaterMark));
                 sb.append(String.format("\t isAssigned: %b%n", snapshot.isAssigned));
                 sb.append(String.format("\t isAvailable: %b%n", snapshot.isAvailable));
             }
-            System.out.println(sb.toString());
+            return sb;
+        }
+
+        private void listPartitionInfo(Map<Integer, PartitionInfoSnapshot> partitionInfo, String storageHost, String storagePort) {
+            System.out.println(getListPartitionInfo(partitionInfo, storageHost, storagePort));
         }
 
         @Override

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/storage/StorageCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/storage/StorageCliTest.java
@@ -147,13 +147,10 @@ public final class StorageCliTest {
             }
             setUpStreams();
 
-
             // no path
-            /*
-             * The partitions themselves and their ids will be wrong. This should only verify if all hosts and ports are being
-             * detected to be displayed. The reason the partitions are wrong has to do with the fact that this
-             * test runs everything in the same JVM. This issue will not exist in production
-             */
+            // The partitions themselves and their ids will be wrong. This should only verify if all hosts and ports are being
+            // detected to be displayed. The reason the partitions are wrong has to do with the fact that this
+            // test runs everything in the same JVM. This issue will not exist in production
             String[] argsNoPath = {
                     "list",
                     "--cli-config-path", configFilePath
@@ -470,7 +467,7 @@ public final class StorageCliTest {
             // Create partitions on each storage node
             for (WaltzStorage waltzStorage : Utils.list(sourceWaltzStorage, destinationWaltzStorage)) {
                 int adminPort = waltzStorage.adminPort;
-                StorageAdminClient adminClient = helper.getStorageAdminClientWithPort(adminPort);
+                StorageAdminClient adminClient = helper.getStorageAdminClientWithAdminPort(adminPort);
                 adminClient.open();
                 for (int i = 0; i < numPartitions; i++) {
                     adminClient.setPartitionAssignment(i, true, false).get();
@@ -733,7 +730,7 @@ public final class StorageCliTest {
             int adminPort = waltzStorage.adminPort;
 
             // Create partitions on each storage node
-            StorageAdminClient adminClient = helper.getStorageAdminClientWithPort(adminPort);
+            StorageAdminClient adminClient = helper.getStorageAdminClientWithAdminPort(adminPort);
             adminClient.open();
             for (int i = 0; i < numPartitions; i++) {
                 adminClient.setPartitionAssignment(i, true, false).get();


### PR DESCRIPTION
* Add option to use list partition command without `storage` specified to display partitions for all storages.
* Create an incomplete unit test. This is because unit tests run all waltz storage and servers on the same JVM.
* Modify `IntegrationTestHelper` to handle multiple storage nodes.