### PR TITLE
Make StoreSessionImpl.BATCH_SIZE configurable in waltz server config

### DIFF
--- a/waltz-server/src/main/java/com/wepay/waltz/server/WaltzServerConfig.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/WaltzServerConfig.java
@@ -41,6 +41,11 @@ public class WaltzServerConfig extends AbstractConfig {
     /** Default optimistic lock table size. */
     public static final int DEFAULT_OPTIMISTIC_LOCK_TABLE_SIZE = 30000;
 
+    /** StoreSession batch size, <code>server.storeSessionBatchSize</code> */
+    public static final String STORE_SESSION_BATCH_SIZE = "server.storeSessionBatchSize";
+    /** Default value for {@link #STORE_SESSION_BATCH_SIZE} config. */
+    public static final int DEFAULT_STORE_SESSION_BATCH_SIZE = 100;
+
     /** Feed cache size. */
     public static final String FEED_CACHE_SIZE = "server.feedCacheSize";
     /** Default feed cache size. */
@@ -117,6 +122,7 @@ public class WaltzServerConfig extends AbstractConfig {
 
             // Partition
             put(OPTIMISTIC_LOCK_TABLE_SIZE, intParser.withDefault(DEFAULT_OPTIMISTIC_LOCK_TABLE_SIZE));
+            put(STORE_SESSION_BATCH_SIZE, intParser.withDefault(DEFAULT_STORE_SESSION_BATCH_SIZE));
             put(FEED_CACHE_SIZE, intParser.withDefault(DEFAULT_FEED_CACHE_SIZE));
             put(MIN_FETCH_SIZE, intParser.withDefault(DEFAULT_MIN_FETCH_SIZE));
             put(REALTIME_THRESHOLD, intParser.withDefault(DEFAULT_REALTIME_THRESHOLD));

--- a/waltz-server/src/main/java/com/wepay/waltz/server/WaltzServerConfig.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/WaltzServerConfig.java
@@ -41,11 +41,6 @@ public class WaltzServerConfig extends AbstractConfig {
     /** Default optimistic lock table size. */
     public static final int DEFAULT_OPTIMISTIC_LOCK_TABLE_SIZE = 30000;
 
-    /** StoreSession batch size, <code>server.storeSessionBatchSize</code> */
-    public static final String STORE_SESSION_BATCH_SIZE = "server.storeSessionBatchSize";
-    /** Default value for {@link #STORE_SESSION_BATCH_SIZE} config. */
-    public static final int DEFAULT_STORE_SESSION_BATCH_SIZE = 100;
-
     /** Feed cache size. */
     public static final String FEED_CACHE_SIZE = "server.feedCacheSize";
     /** Default feed cache size. */
@@ -70,6 +65,11 @@ public class WaltzServerConfig extends AbstractConfig {
     public static final String TRANSACTION_DATA_CACHE_ALLOCATION = "server.transactionDataCacheAllocation";
     /** Default transaction data cache allocation. */
     public static final String DEFAULT_TRANSACTION_DATA_CACHE_ALLOCATION = "heap"; // heap or direct
+
+    /** Maximum batch size, <code>storage.maxBatchSize</code> */
+    public static final String MAX_BATCH_SIZE = "storage.maxBatchSize";
+    /** Default value for {@link #MAX_BATCH_SIZE} config. */
+    public static final int DEFAULT_MAX_BATCH_SIZE = 100;
 
     /** Initial retry interval. */
     public static final String INITIAL_RETRY_INTERVAL = "storage.initialRetryInterval";
@@ -122,7 +122,6 @@ public class WaltzServerConfig extends AbstractConfig {
 
             // Partition
             put(OPTIMISTIC_LOCK_TABLE_SIZE, intParser.withDefault(DEFAULT_OPTIMISTIC_LOCK_TABLE_SIZE));
-            put(STORE_SESSION_BATCH_SIZE, intParser.withDefault(DEFAULT_STORE_SESSION_BATCH_SIZE));
             put(FEED_CACHE_SIZE, intParser.withDefault(DEFAULT_FEED_CACHE_SIZE));
             put(MIN_FETCH_SIZE, intParser.withDefault(DEFAULT_MIN_FETCH_SIZE));
             put(REALTIME_THRESHOLD, intParser.withDefault(DEFAULT_REALTIME_THRESHOLD));
@@ -131,6 +130,7 @@ public class WaltzServerConfig extends AbstractConfig {
                 .withValidator(new CacheAllocationValidator()));
 
             // Storage
+            put(MAX_BATCH_SIZE, intParser.withDefault(DEFAULT_MAX_BATCH_SIZE));
             put(INITIAL_RETRY_INTERVAL, longParser.withDefault(DEFAULT_INITIAL_RETRY_INTERVAL));
             put(MAX_RETRY_INTERVAL, longParser.withDefault(DEFAULT_MAX_RETRY_INTERVAL));
             put(CHECKPOINT_INTERVAL, intParser.withDefault(DEFAULT_CHECKPOINT_INTERVAL));

--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreImpl.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreImpl.java
@@ -80,7 +80,7 @@ public class StoreImpl implements Store {
                 new StoreSessionManager(
                     partitionId,
                     generation,
-                    (int) config.get(WaltzServerConfig.STORE_SESSION_BATCH_SIZE),
+                    (int) config.get(WaltzServerConfig.MAX_BATCH_SIZE),
                     replicaSessionManager,
                     zkClient,
                     znode

--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreImpl.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreImpl.java
@@ -77,7 +77,14 @@ public class StoreImpl implements Store {
             ZNode znode = new ZNode(partitionRoot, Integer.toString(partitionId));
 
             StoreSessionManager storeSessionManager =
-                new StoreSessionManager(partitionId, generation, replicaSessionManager, zkClient, znode);
+                new StoreSessionManager(
+                    partitionId,
+                    generation,
+                    (int) config.get(WaltzServerConfig.STORE_SESSION_BATCH_SIZE),
+                    replicaSessionManager,
+                    zkClient,
+                    znode
+                );
 
             return new StorePartitionImpl(storeSessionManager, config);
 

--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionImpl.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionImpl.java
@@ -29,7 +29,7 @@ public class StoreSessionImpl implements StoreSession {
     public final int partitionId;
     public final long sessionId;
 
-    private final int batchSize;
+    private final int maxBatchSize;
     private final int numReplicas;
     private final int quorum;
     private final ArrayList<ReplicaSession> replicaSessions;
@@ -52,7 +52,7 @@ public class StoreSessionImpl implements StoreSession {
      * @param partitionId The partition Id.
      * @param generation The generation number.
      * @param sessionId The session Id.
-     * @param batchSize Maximum number of pending {@link StoreAppendRequest}s processed at a time.
+     * @param maxBatchSize Maximum number of pending {@link StoreAppendRequest}s processed at a time.
      * @param replicaSessions List of {@link ReplicaSession}s.
      * @param zkClient The ZooKeeperClient used in Waltz cluster.
      * @param znode Path to the znode.
@@ -61,7 +61,7 @@ public class StoreSessionImpl implements StoreSession {
         final int partitionId,
         final int generation,
         final long sessionId,
-        final int batchSize,
+        final int maxBatchSize,
         final ArrayList<ReplicaSession> replicaSessions,
         final ZooKeeperClient zkClient,
         final ZNode znode
@@ -69,7 +69,7 @@ public class StoreSessionImpl implements StoreSession {
         this.generation = generation;
         this.partitionId = partitionId;
         this.sessionId = sessionId;
-        this.batchSize = batchSize;
+        this.maxBatchSize = maxBatchSize;
         this.numReplicas = replicaSessions.size();
         this.quorum = this.numReplicas / 2 + 1;
         this.replicaSessions = replicaSessions;
@@ -169,7 +169,7 @@ public class StoreSessionImpl implements StoreSession {
                 }
 
                 // Wait until the queue has enough space.
-                while (requestQueue.size() > batchSize * 2) {
+                while (requestQueue.size() > maxBatchSize * 2) {
                     try {
                         wait();
                     } catch (InterruptedException ex) {
@@ -338,7 +338,7 @@ public class StoreSessionImpl implements StoreSession {
 
     private void doAppend() {
         synchronized (requestQueueProcessingLock) {
-            List<StoreAppendRequest> batch = requestQueue.dequeue(batchSize);
+            List<StoreAppendRequest> batch = requestQueue.dequeue(maxBatchSize);
 
             if (batch != null && batch.size() > 0) {
                 synchronized (this) {

--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionImpl.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionImpl.java
@@ -24,12 +24,12 @@ import java.util.concurrent.LinkedBlockingDeque;
 public class StoreSessionImpl implements StoreSession {
 
     private static final Logger logger = Logging.getLogger(StoreSessionImpl.class);
-    private static final int BATCH_SIZE = 100;
 
     public final int generation;
     public final int partitionId;
     public final long sessionId;
 
+    private final int batchSize;
     private final int numReplicas;
     private final int quorum;
     private final ArrayList<ReplicaSession> replicaSessions;
@@ -52,6 +52,7 @@ public class StoreSessionImpl implements StoreSession {
      * @param partitionId The partition Id.
      * @param generation The generation number.
      * @param sessionId The session Id.
+     * @param batchSize Maximum number of pending {@link StoreAppendRequest}s processed at a time.
      * @param replicaSessions List of {@link ReplicaSession}s.
      * @param zkClient The ZooKeeperClient used in Waltz cluster.
      * @param znode Path to the znode.
@@ -60,6 +61,7 @@ public class StoreSessionImpl implements StoreSession {
         final int partitionId,
         final int generation,
         final long sessionId,
+        final int batchSize,
         final ArrayList<ReplicaSession> replicaSessions,
         final ZooKeeperClient zkClient,
         final ZNode znode
@@ -67,6 +69,7 @@ public class StoreSessionImpl implements StoreSession {
         this.generation = generation;
         this.partitionId = partitionId;
         this.sessionId = sessionId;
+        this.batchSize = batchSize;
         this.numReplicas = replicaSessions.size();
         this.quorum = this.numReplicas / 2 + 1;
         this.replicaSessions = replicaSessions;
@@ -166,7 +169,7 @@ public class StoreSessionImpl implements StoreSession {
                 }
 
                 // Wait until the queue has enough space.
-                while (requestQueue.size() > BATCH_SIZE * 2) {
+                while (requestQueue.size() > batchSize * 2) {
                     try {
                         wait();
                     } catch (InterruptedException ex) {
@@ -335,7 +338,7 @@ public class StoreSessionImpl implements StoreSession {
 
     private void doAppend() {
         synchronized (requestQueueProcessingLock) {
-            List<StoreAppendRequest> batch = requestQueue.dequeue(BATCH_SIZE);
+            List<StoreAppendRequest> batch = requestQueue.dequeue(batchSize);
 
             if (batch != null && batch.size() > 0) {
                 synchronized (this) {

--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
@@ -41,11 +41,13 @@ public class StoreSessionManager {
     private final AtomicInteger generation;
     private volatile boolean healthy = true;
     private volatile StoreSession currentSession;
+    private final int storeSessionBatchSize;
 
     /**
      * Class constructor.
      * @param partitionId The partition Id.
      * @param generation The generation number.
+     * @param storeSessionBatchSize Batch size in {@link StoreSessionImpl}.
      * @param replicaSessionManager The {@link ReplicaSessionManager}.
      * @param zkClient The Zoo Keeper Client used in the Waltz cluster.
      * @param znode Path to the znode.
@@ -53,12 +55,14 @@ public class StoreSessionManager {
     public StoreSessionManager(
         final int partitionId,
         final int generation,
+        final int storeSessionBatchSize,
         final ReplicaSessionManager replicaSessionManager,
         final ZooKeeperClient zkClient,
         final ZNode znode
     ) {
         this.partitionId = partitionId;
         this.generation = new AtomicInteger(generation);
+        this.storeSessionBatchSize = storeSessionBatchSize;
         this.zkClient = zkClient;
         this.znode = znode;
         this.replicaSessionManager = replicaSessionManager;
@@ -183,7 +187,7 @@ public class StoreSessionManager {
 
                 // Create a new session
                 ArrayList<ReplicaSession> replicaSessions = replicaSessionManager.getReplicaSessions(partitionId, sessionId);
-                session = new StoreSessionImpl(partitionId, generation, sessionId, replicaSessions, zkClient, znode);
+                session = new StoreSessionImpl(partitionId, generation, sessionId, storeSessionBatchSize, replicaSessions, zkClient, znode);
                 session.open();
                 healthy = true;
 

--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
@@ -41,13 +41,13 @@ public class StoreSessionManager {
     private final AtomicInteger generation;
     private volatile boolean healthy = true;
     private volatile StoreSession currentSession;
-    private final int storeSessionBatchSize;
+    private final int maxBatchSize;
 
     /**
      * Class constructor.
      * @param partitionId The partition Id.
      * @param generation The generation number.
-     * @param storeSessionBatchSize Batch size in {@link StoreSessionImpl}.
+     * @param maxBatchSize Batch size in {@link StoreSessionImpl}.
      * @param replicaSessionManager The {@link ReplicaSessionManager}.
      * @param zkClient The Zoo Keeper Client used in the Waltz cluster.
      * @param znode Path to the znode.
@@ -55,14 +55,14 @@ public class StoreSessionManager {
     public StoreSessionManager(
         final int partitionId,
         final int generation,
-        final int storeSessionBatchSize,
+        final int maxBatchSize,
         final ReplicaSessionManager replicaSessionManager,
         final ZooKeeperClient zkClient,
         final ZNode znode
     ) {
         this.partitionId = partitionId;
         this.generation = new AtomicInteger(generation);
-        this.storeSessionBatchSize = storeSessionBatchSize;
+        this.maxBatchSize = maxBatchSize;
         this.zkClient = zkClient;
         this.znode = znode;
         this.replicaSessionManager = replicaSessionManager;
@@ -187,7 +187,7 @@ public class StoreSessionManager {
 
                 // Create a new session
                 ArrayList<ReplicaSession> replicaSessions = replicaSessionManager.getReplicaSessions(partitionId, sessionId);
-                session = new StoreSessionImpl(partitionId, generation, sessionId, storeSessionBatchSize, replicaSessions, zkClient, znode);
+                session = new StoreSessionImpl(partitionId, generation, sessionId, maxBatchSize, replicaSessions, zkClient, znode);
                 session.open();
                 healthy = true;
 

--- a/waltz-server/src/test/java/com/wepay/waltz/server/WaltzServerConfigTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/server/WaltzServerConfigTest.java
@@ -32,11 +32,11 @@ public class WaltzServerConfigTest {
         map.put(WaltzServerConfig.SERVER_PORT, "8888");
 
         map.put(WaltzServerConfig.OPTIMISTIC_LOCK_TABLE_SIZE, "2000");
-        map.put(WaltzServerConfig.STORE_SESSION_BATCH_SIZE, "100");
         map.put(WaltzServerConfig.FEED_CACHE_SIZE, "1000");
         map.put(WaltzServerConfig.MIN_FETCH_SIZE, "50");
         map.put(WaltzServerConfig.REALTIME_THRESHOLD, "500");
 
+        map.put(WaltzServerConfig.MAX_BATCH_SIZE, "500");
         map.put(WaltzServerConfig.INITIAL_RETRY_INTERVAL, "30");
         map.put(WaltzServerConfig.MAX_RETRY_INTERVAL, "30000");
 
@@ -63,10 +63,6 @@ public class WaltzServerConfigTest {
         assertTrue(value instanceof Integer);
         assertEquals(2000, value);
 
-        value = config.get(WaltzServerConfig.STORE_SESSION_BATCH_SIZE);
-        assertTrue(value instanceof Integer);
-        assertEquals(100, value);
-
         value = config.get(WaltzServerConfig.FEED_CACHE_SIZE);
         assertTrue(value instanceof Integer);
         assertEquals(1000, value);
@@ -76,6 +72,10 @@ public class WaltzServerConfigTest {
         assertEquals(50, value);
 
         value = config.get(WaltzServerConfig.REALTIME_THRESHOLD);
+        assertTrue(value instanceof Integer);
+        assertEquals(500, value);
+
+        value = config.get(WaltzServerConfig.MAX_BATCH_SIZE);
         assertTrue(value instanceof Integer);
         assertEquals(500, value);
 
@@ -124,10 +124,6 @@ public class WaltzServerConfigTest {
         assertTrue(value instanceof Integer);
         assertEquals(WaltzServerConfig.DEFAULT_OPTIMISTIC_LOCK_TABLE_SIZE, value);
 
-        value = config.get(WaltzServerConfig.STORE_SESSION_BATCH_SIZE);
-        assertTrue(value instanceof Integer);
-        assertEquals(WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE, value);
-
         value = config.get(WaltzServerConfig.FEED_CACHE_SIZE);
         assertTrue(value instanceof Integer);
         assertEquals(WaltzServerConfig.DEFAULT_FEED_CACHE_SIZE, value);
@@ -139,6 +135,10 @@ public class WaltzServerConfigTest {
         value = config.get(WaltzServerConfig.REALTIME_THRESHOLD);
         assertTrue(value instanceof Integer);
         assertEquals(WaltzServerConfig.DEFAULT_REALTIME_THRESHOLD, value);
+
+        value = config.get(WaltzServerConfig.MAX_BATCH_SIZE);
+        assertTrue(value instanceof Integer);
+        assertEquals(WaltzServerConfig.DEFAULT_MAX_BATCH_SIZE, value);
 
         value = config.get(WaltzServerConfig.INITIAL_RETRY_INTERVAL);
         assertTrue(value instanceof Long);

--- a/waltz-server/src/test/java/com/wepay/waltz/server/WaltzServerConfigTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/server/WaltzServerConfigTest.java
@@ -32,6 +32,7 @@ public class WaltzServerConfigTest {
         map.put(WaltzServerConfig.SERVER_PORT, "8888");
 
         map.put(WaltzServerConfig.OPTIMISTIC_LOCK_TABLE_SIZE, "2000");
+        map.put(WaltzServerConfig.STORE_SESSION_BATCH_SIZE, "100");
         map.put(WaltzServerConfig.FEED_CACHE_SIZE, "1000");
         map.put(WaltzServerConfig.MIN_FETCH_SIZE, "50");
         map.put(WaltzServerConfig.REALTIME_THRESHOLD, "500");
@@ -61,6 +62,10 @@ public class WaltzServerConfigTest {
         value = config.get(WaltzServerConfig.OPTIMISTIC_LOCK_TABLE_SIZE);
         assertTrue(value instanceof Integer);
         assertEquals(2000, value);
+
+        value = config.get(WaltzServerConfig.STORE_SESSION_BATCH_SIZE);
+        assertTrue(value instanceof Integer);
+        assertEquals(100, value);
 
         value = config.get(WaltzServerConfig.FEED_CACHE_SIZE);
         assertTrue(value instanceof Integer);
@@ -118,6 +123,10 @@ public class WaltzServerConfigTest {
         value = config.get(WaltzServerConfig.OPTIMISTIC_LOCK_TABLE_SIZE);
         assertTrue(value instanceof Integer);
         assertEquals(WaltzServerConfig.DEFAULT_OPTIMISTIC_LOCK_TABLE_SIZE, value);
+
+        value = config.get(WaltzServerConfig.STORE_SESSION_BATCH_SIZE);
+        assertTrue(value instanceof Integer);
+        assertEquals(WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE, value);
 
         value = config.get(WaltzServerConfig.FEED_CACHE_SIZE);
         assertTrue(value instanceof Integer);

--- a/waltz-server/src/test/java/com/wepay/waltz/store/internal/StorePartitionTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/store/internal/StorePartitionTest.java
@@ -47,7 +47,7 @@ public class StorePartitionTest {
                 new StoreSessionManager(
                     partitionId,
                     generation,
-                    WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                    WaltzServerConfig.DEFAULT_MAX_BATCH_SIZE,
                     replicaSessionManager,
                     zkClient,
                     znode
@@ -111,7 +111,7 @@ public class StorePartitionTest {
                 new StoreSessionManager(
                     partitionId,
                     generation,
-                    WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                    WaltzServerConfig.DEFAULT_MAX_BATCH_SIZE,
                     replicaSessionManager,
                     zkClient,
                     znode

--- a/waltz-server/src/test/java/com/wepay/waltz/store/internal/StorePartitionTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/store/internal/StorePartitionTest.java
@@ -43,7 +43,15 @@ public class StorePartitionTest {
             ZNode znode = new ZNode(root, Integer.toString(partitionId));
 
             ReplicaSessionManager replicaSessionManager = new TestReplicaSessionManager(1, NUM_REPLICAS);
-            StoreSessionManager storeSessionManager = new StoreSessionManager(partitionId, generation, replicaSessionManager, zkClient, znode);
+            StoreSessionManager storeSessionManager =
+                new StoreSessionManager(
+                    partitionId,
+                    generation,
+                    WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                    replicaSessionManager,
+                    zkClient,
+                    znode
+                );
             StorePartitionImpl partition = new StorePartitionImpl(storeSessionManager, config);
 
             try {
@@ -99,7 +107,15 @@ public class StorePartitionTest {
             ZNode znode = new ZNode(root, Integer.toString(partitionId));
 
             TestReplicaSessionManager replicaSessionManager = new TestReplicaSessionManager(1, NUM_REPLICAS);
-            StoreSessionManager storeSessionManager = new StoreSessionManager(partitionId, generation, replicaSessionManager, zkClient, znode);
+            StoreSessionManager storeSessionManager =
+                new StoreSessionManager(
+                    partitionId,
+                    generation,
+                    WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                    replicaSessionManager,
+                    zkClient,
+                    znode
+                );
             StorePartitionImpl partition = new StorePartitionImpl(storeSessionManager, config);
 
             try {

--- a/waltz-server/src/test/java/com/wepay/waltz/store/internal/StoreSessionImplTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/store/internal/StoreSessionImplTest.java
@@ -72,7 +72,7 @@ public class StoreSessionImplTest {
                         partitionId,
                         generation,
                         sessionId,
-                        WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                        WaltzServerConfig.DEFAULT_MAX_BATCH_SIZE,
                         replicaSessions,
                         zkClient,
                         znode

--- a/waltz-server/src/test/java/com/wepay/waltz/store/internal/StoreSessionImplTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/store/internal/StoreSessionImplTest.java
@@ -3,6 +3,7 @@ package com.wepay.waltz.store.internal;
 import com.wepay.waltz.common.message.Record;
 import com.wepay.waltz.common.message.RecordHeader;
 import com.wepay.waltz.common.message.ReqId;
+import com.wepay.waltz.server.WaltzServerConfig;
 import com.wepay.waltz.store.TestUtils;
 import com.wepay.waltz.store.exception.GenerationMismatchException;
 import com.wepay.waltz.store.internal.metadata.PartitionMetadata;
@@ -66,7 +67,16 @@ public class StoreSessionImplTest {
 
             try {
                 ArrayList<ReplicaSession> replicaSessions = replicaSessionManager.getReplicaSessions(partitionId, sessionId);
-                StoreSessionImpl session = new StoreSessionImpl(partitionId, generation, sessionId, replicaSessions, zkClient, znode);
+                StoreSessionImpl session =
+                    new StoreSessionImpl(
+                        partitionId,
+                        generation,
+                        sessionId,
+                        WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                        replicaSessions,
+                        zkClient,
+                        znode
+                    );
                 session.open();
                 try {
                     // Test generation mismatch

--- a/waltz-server/src/test/java/com/wepay/waltz/store/internal/StoreSessionManagerTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/store/internal/StoreSessionManagerTest.java
@@ -48,7 +48,7 @@ public class StoreSessionManagerTest {
                 new StoreSessionManager(
                     partitionId,
                     generation,
-                    WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                    WaltzServerConfig.DEFAULT_MAX_BATCH_SIZE,
                     replicaSessionManager,
                     zkClient,
                     znode
@@ -139,7 +139,7 @@ public class StoreSessionManagerTest {
                 new StoreSessionManager(
                     partitionId,
                     generation,
-                    WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                    WaltzServerConfig.DEFAULT_MAX_BATCH_SIZE,
                     replicaSessionManager,
                     zkClient,
                     znode
@@ -263,7 +263,7 @@ public class StoreSessionManagerTest {
                 new StoreSessionManager(
                     partitionId,
                     generation,
-                    WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                    WaltzServerConfig.DEFAULT_MAX_BATCH_SIZE,
                     replicaSessionManager,
                     zkClient,
                     znode
@@ -297,7 +297,7 @@ public class StoreSessionManagerTest {
                     new StoreSessionManager(
                         partitionId,
                         generation + 1,
-                        WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                        WaltzServerConfig.DEFAULT_MAX_BATCH_SIZE,
                         replicaSessionManager,
                         zkClient,
                         znode

--- a/waltz-server/src/test/java/com/wepay/waltz/store/internal/StoreSessionManagerTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/store/internal/StoreSessionManagerTest.java
@@ -3,6 +3,7 @@ package com.wepay.waltz.store.internal;
 import com.wepay.waltz.common.message.Record;
 import com.wepay.waltz.common.message.ReqId;
 import com.wepay.waltz.common.util.BackoffTimer;
+import com.wepay.waltz.server.WaltzServerConfig;
 import com.wepay.waltz.store.TestUtils;
 import com.wepay.waltz.store.exception.GenerationMismatchException;
 import com.wepay.waltz.store.exception.SessionClosedException;
@@ -43,7 +44,15 @@ public class StoreSessionManagerTest {
 
             ReplicaSessionManager replicaSessionManager = new TestReplicaSessionManager(1, NUM_REPLICAS);
 
-            StoreSessionManager storeSessionManager = new StoreSessionManager(partitionId, generation, replicaSessionManager, zkClient, znode);
+            StoreSessionManager storeSessionManager =
+                new StoreSessionManager(
+                    partitionId,
+                    generation,
+                    WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                    replicaSessionManager,
+                    zkClient,
+                    znode
+                );
             StoreSession session;
             try {
                 long expectedHighWaterMark = -1L;
@@ -126,7 +135,15 @@ public class StoreSessionManagerTest {
 
             TestReplicaSessionManager replicaSessionManager = new TestReplicaSessionManager(1, NUM_REPLICAS);
 
-            StoreSessionManager storeSessionManager = new StoreSessionManager(partitionId, generation, replicaSessionManager, zkClient, znode);
+            StoreSessionManager storeSessionManager =
+                new StoreSessionManager(
+                    partitionId,
+                    generation,
+                    WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                    replicaSessionManager,
+                    zkClient,
+                    znode
+                );
             StoreSession session = null;
             try {
                 long expectedHighWaterMark = -1L;
@@ -242,7 +259,15 @@ public class StoreSessionManagerTest {
             ZNode znode = new ZNode(root, Integer.toString(partitionId));
 
             TestReplicaSessionManager replicaSessionManager = new TestReplicaSessionManager(1, NUM_REPLICAS);
-            StoreSessionManager storeSessionManager1 = new StoreSessionManager(partitionId, generation, replicaSessionManager, zkClient, znode);
+            StoreSessionManager storeSessionManager1 =
+                new StoreSessionManager(
+                    partitionId,
+                    generation,
+                    WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                    replicaSessionManager,
+                    zkClient,
+                    znode
+                );
             StoreSessionManager storeSessionManager2 = null;
             StoreSession session1;
             StoreSession session2;
@@ -268,7 +293,15 @@ public class StoreSessionManagerTest {
                 }
 
                 // Open another session manager with new generation
-                storeSessionManager2 = new StoreSessionManager(partitionId, generation + 1, replicaSessionManager, zkClient, znode);
+                storeSessionManager2 =
+                    new StoreSessionManager(
+                        partitionId,
+                        generation + 1,
+                        WaltzServerConfig.DEFAULT_STORE_SESSION_BATCH_SIZE,
+                        replicaSessionManager,
+                        zkClient,
+                        znode
+                    );
 
                 session2 = storeSessionManager2.getStoreSession();
                 assertEquals(expectedHighWaterMark, session2.highWaterMark());


### PR DESCRIPTION
Issues: https://github.com/wepay/waltz/issues/9

-- Made StoreSessionImpl.BATCH_SIZE configurable, with default as 100, via waltz server config.
-- Updated corresponding unit tests.
