### PR TITLE
Read config path from System.properties

### DIFF
--- a/docs/waltz-setup.md
+++ b/docs/waltz-setup.md
@@ -27,11 +27,11 @@ Step 1: Use `create` command to create a cluster
 ```
 waltz_uber=/path/to/waltz-uber-X.Y.Z.jar
 java ${waltz_uber+-cp ${waltz_uber}} \
+    -Dwaltz.config=${cli_config_path?} \
     com.wepay.waltz.tools.zk.ZooKeeperCli \
     create \
     --name ${cluster_name?} \
-    --partitions ${partition_count?} \
-    --cli-config-path ${cli_config_path?}
+    --partitions ${partition_count?}
 ```
 
 Step 2: Use `add-storage-node` command to add storage node(s)

--- a/waltz-test/src/main/python/waltz_ducktape/services/cli/client_cli.py
+++ b/waltz-test/src/main/python/waltz_ducktape/services/cli/client_cli.py
@@ -27,12 +27,14 @@ class ClientCli(Cli):
             --num-active-partitions <number of partitions to interact with>
         """
         cmd_arr = [
-            "java -Dlog4j.configuration=file:/etc/waltz-client/waltz-log4j.cfg", self.java_cli_class_name(),
+            "java -Dwaltz.config={} -Dlog4j.configuration=file:/etc/waltz-client/waltz-log4j.cfg".format(
+                self.cli_config_path),
+            self.java_cli_class_name(),
             "validate",
             "--txn-per-client", txn_per_client,
             "--num-clients", num_clients,
             "--interval", interval,
-            "--cli-config-path", self.cli_config_path,
+            "--high-watermark {}".format(high_watermark) if high_watermark is not None else "",
             "--num-active-partitions {}".format(num_active_partitions) if num_active_partitions is not None else ""
         ]
         return self.build_cmd(cmd_arr)

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/client/ClientCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/client/ClientCli.java
@@ -123,7 +123,7 @@ public final class ClientCli extends SubcommandCli {
                     .build();
             Option cfgPathOption = Option.builder("c")
                     .longOpt("cli-config-path")
-                    .desc("Specify client cli config file path")
+                    .desc("Specify client cli config file path (overrides system property waltz.config)")
                     .hasArg()
                     .build();
             Option numActivePartitionOption = Option.builder("ap")
@@ -136,7 +136,7 @@ public final class ClientCli extends SubcommandCli {
             txnPerClientOption.setRequired(true);
             numClientsOption.setRequired(true);
             intervalOption.setRequired(true);
-            cfgPathOption.setRequired(true);
+            cfgPathOption.setRequired(false);
             numActivePartitionOption.setRequired(false);
 
             options.addOption(txnPerClientOption);
@@ -162,7 +162,10 @@ public final class ClientCli extends SubcommandCli {
                 if (avgInterval < 0) {
                     throw new IllegalArgumentException("Found negative: interval must be greater or equals to 0");
                 }
-                String configFilePath = cmd.getOptionValue("cli-config-path");
+                String configFilePath = cmd.getOptionValue(
+                        "cli-config-path",
+                        System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+                );
                 WaltzClientConfig waltzClientConfig = getWaltzClientConfig(configFilePath);
 
                 // check optional argument

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/performance/PerformanceCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/performance/PerformanceCli.java
@@ -116,7 +116,7 @@ public final class PerformanceCli extends SubcommandCli {
             txnPerThreadOption.setRequired(true);
             numThreadOption.setRequired(true);
             intervalOption.setRequired(true);
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
             numActivePartitionOption.setRequired(false);
             lockPoolSizeOption.setRequired(false);
 
@@ -150,7 +150,12 @@ public final class PerformanceCli extends SubcommandCli {
                 if (avgInterval < 0) {
                     throw new IllegalArgumentException("Found negative: interval must be greater or equals to 0");
                 }
-                waltzClientConfig = getWaltzClientConfig(cmd.getOptionValue("cli-config-path"));
+                waltzClientConfig = getWaltzClientConfig(
+                        cmd.getOptionValue(
+                                "cli-config-path",
+                                System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+                        )
+                );
 
                 // check optional argument
                 if (cmd.hasOption("num-active-partitions")) {
@@ -389,7 +394,7 @@ public final class PerformanceCli extends SubcommandCli {
                     .build();
             txnSizeOption.setRequired(true);
             numTxnOption.setRequired(true);
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
             numActivePartitionOption.setRequired(false);
 
             options.addOption(txnSizeOption);
@@ -413,7 +418,12 @@ public final class PerformanceCli extends SubcommandCli {
                 }
                 allTxnReceived = new CountDownLatch(numTxn);
                 allTxnRead = new CountDownLatch(numTxn);
-                waltzClientConfig = getWaltzClientConfig(cmd.getOptionValue("cli-config-path"));
+                waltzClientConfig = getWaltzClientConfig(
+                        cmd.getOptionValue(
+                                "cli-config-path",
+                                System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+                        )
+                );
 
                 // check optional argument
                 if (cmd.hasOption("num-active-partitions")) {

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
@@ -86,14 +86,17 @@ public final class StorageCli extends SubcommandCli {
                     .hasArg()
                     .build();
             storageOption.setRequired(false);
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
             options.addOption(storageOption);
             options.addOption(cliCfgOption);
         }
 
         @Override
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
-            String cliConfigPath = cmd.getOptionValue("cli-config-path");
+            String cliConfigPath = cmd.getOptionValue(
+                "cli-config-path",
+                System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+            );
             String providedHostAndPort = cmd.getOptionValue("storage");
             List<String[]> hostsAndPorts;
             if (providedHostAndPort == null) {
@@ -263,7 +266,7 @@ public final class StorageCli extends SubcommandCli {
 
             storageOption.setRequired(true);
             partitionOption.setRequired(true);
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
 
             options.addOption(storageOption);
             options.addOption(partitionOption);
@@ -274,7 +277,10 @@ public final class StorageCli extends SubcommandCli {
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
             String hostAndPort = cmd.getOptionValue("storage");
             String partitionId = cmd.getOptionValue("partition");
-            String cliConfigPath = cmd.getOptionValue("cli-config-path");
+            String cliConfigPath = cmd.getOptionValue(
+                    "cli-config-path",
+                    System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+            );
 
             try {
                 String[] hostAndPortArray = hostAndPort.split(":");
@@ -363,7 +369,7 @@ public final class StorageCli extends SubcommandCli {
             storageOption.setRequired(true);
             partitionOption.setRequired(true);
             onlineOption.setRequired(true);
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
 
             options.addOption(storageOption);
             options.addOption(partitionOption);
@@ -376,7 +382,10 @@ public final class StorageCli extends SubcommandCli {
             String hostAndPort = cmd.getOptionValue("storage");
             String partitionId = cmd.getOptionValue("partition");
             String isOnline = cmd.getOptionValue("online");
-            String cliConfigPath = cmd.getOptionValue("cli-config-path");
+            String cliConfigPath = cmd.getOptionValue(
+                "cli-config-path",
+                System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+            );
 
             try {
                 String[] hostAndPortArray = hostAndPort.split(":");
@@ -466,7 +475,7 @@ public final class StorageCli extends SubcommandCli {
 
             storageOption.setRequired(true);
             partitionOption.setRequired(true);
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
             deleteStorageFilesOption.setRequired(false);
 
             options.addOption(storageOption);
@@ -479,7 +488,10 @@ public final class StorageCli extends SubcommandCli {
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
             String hostAndPort = cmd.getOptionValue("storage");
             String partitionId = cmd.getOptionValue("partition");
-            String cliConfigPath = cmd.getOptionValue("cli-config-path");
+            String cliConfigPath = cmd.getOptionValue(
+                "cli-config-path",
+                System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+            );
             boolean deleteStorageFiles = false;
 
             if (cmd.hasOption("delete-storage-files")) {
@@ -609,7 +621,7 @@ public final class StorageCli extends SubcommandCli {
             destinationStoragePortOption.setRequired(true);
             partitionOption.setRequired(true);
             batchSizeOption.setRequired(true);
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
             sourceSslOption.setRequired(false);
             destinationSslOption.setRequired(false);
 
@@ -630,7 +642,10 @@ public final class StorageCli extends SubcommandCli {
             String destinationStoragePort = cmd.getOptionValue("destination-storage-port");
             String partitionId = cmd.getOptionValue("partition");
             String batchSize = cmd.getOptionValue("batch-size");
-            String cliConfigPath = cmd.getOptionValue("cli-config-path");
+            String cliConfigPath = cmd.getOptionValue(
+                    "cli-config-path",
+                    System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+            );
             String sourceSslConfigPath = cmd.getOptionValue("source-ssl-config-path");
             String destinationSslConfigPath = cmd.getOptionValue("destination-ssl-config-path");
 
@@ -743,14 +758,17 @@ public final class StorageCli extends SubcommandCli {
                     .hasArg()
                     .build();
 
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
 
             options.addOption(cliCfgOption);
         }
 
         @Override
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
-            String cliConfigPath = cmd.getOptionValue("cli-config-path");
+            String cliConfigPath = cmd.getOptionValue(
+                    "cli-config-path",
+                    System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+            );
 
             try {
                 syncPartitionAssignments(cliConfigPath);
@@ -818,7 +836,7 @@ public final class StorageCli extends SubcommandCli {
                     .desc("Specify the cli config file path required for zooKeeper connection string, zooKeeper root path and SSL config")
                     .hasArg()
                     .build();
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
 
             options.addOption(cliCfgOption);
         }
@@ -826,7 +844,10 @@ public final class StorageCli extends SubcommandCli {
         @Override
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
             try {
-                String cliConfigPath = cmd.getOptionValue("cli-config-path");
+                String cliConfigPath = cmd.getOptionValue(
+                        "cli-config-path",
+                        System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+                );
 
                 validateConnectivity(cliConfigPath);
             } catch (Exception e) {
@@ -951,7 +972,7 @@ public final class StorageCli extends SubcommandCli {
             storageOption.setRequired(true);
             storagePortOption.setRequired(true);
             partitionOption.setRequired(true);
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
             offlineOption.setRequired(false);
 
             options.addOption(storageOption);
@@ -966,7 +987,10 @@ public final class StorageCli extends SubcommandCli {
             String hostAndPort = cmd.getOptionValue("storage");
             String storagePort = cmd.getOptionValue("storage-port");
             String partitionId = cmd.getOptionValue("partition");
-            String cliConfigPath = cmd.getOptionValue("cli-config-path");
+            String cliConfigPath = cmd.getOptionValue(
+                    "cli-config-path",
+                    System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+            );
             boolean usedByOfflineRecovery = cmd.hasOption("offline");
 
             try {

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
@@ -92,7 +92,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                 .hasArg()
                 .build();
 
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
 
             options.addOption(cliCfgOption);
         }
@@ -101,7 +101,10 @@ public final class ZooKeeperCli extends SubcommandCli {
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
             ZooKeeperClient zkClient = null;
             try {
-                String cliConfigPath = cmd.getOptionValue("cli-config-path");
+                String cliConfigPath = cmd.getOptionValue(
+                        "cli-config-path",
+                        System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+                );
                 CliConfig cliConfig = CliConfig.parseCliConfigFile(cliConfigPath);
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
@@ -223,7 +226,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                 .hasArg()
                 .build();
 
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
 
             options.addOption(cliCfgOption);
         }
@@ -232,7 +235,10 @@ public final class ZooKeeperCli extends SubcommandCli {
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
             ZooKeeperClient zkClient = null;
             try {
-                String cliConfigPath = cmd.getOptionValue("cli-config-path");
+                String cliConfigPath = cmd.getOptionValue(
+                        "cli-config-path",
+                        System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+                );
                 CliConfig cliConfig = CliConfig.parseCliConfigFile(cliConfigPath);
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
@@ -288,7 +294,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                     .hasArg()
                     .build();
 
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
             nameOption.setRequired(true);
             partitionsOption.setRequired(true);
 
@@ -301,7 +307,10 @@ public final class ZooKeeperCli extends SubcommandCli {
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
             ZooKeeperClient zkClient = null;
             try {
-                String cliConfigPath = cmd.getOptionValue("cli-config-path");
+                String cliConfigPath = cmd.getOptionValue(
+                        "cli-config-path",
+                        System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+                );
                 CliConfig cliConfig = CliConfig.parseCliConfigFile(cliConfigPath);
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
@@ -412,7 +421,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                     .hasArg()
                     .build();
 
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
             nameOption.setRequired(true);
             forceOption.setRequired(false);
 
@@ -425,7 +434,10 @@ public final class ZooKeeperCli extends SubcommandCli {
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
             ZooKeeperClient zkClient = null;
             try {
-                String cliConfigPath = cmd.getOptionValue("cli-config-path");
+                String cliConfigPath = cmd.getOptionValue(
+                        "cli-config-path",
+                        System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+                );
                 CliConfig cliConfig = CliConfig.parseCliConfigFile(cliConfigPath);
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
@@ -508,7 +520,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                     .hasArg()
                     .build();
 
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
             storageOption.setRequired(true);
             storageAdminPortOption.setRequired(true);
             groupOption.setRequired(true);
@@ -523,7 +535,10 @@ public final class ZooKeeperCli extends SubcommandCli {
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
             ZooKeeperClient zkClient = null;
             try {
-                String cliConfigPath = cmd.getOptionValue("cli-config-path");
+                String cliConfigPath = cmd.getOptionValue(
+                        "cli-config-path",
+                        System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+                );
                 CliConfig cliConfig = CliConfig.parseCliConfigFile(cliConfigPath);
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
@@ -579,7 +594,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                     .hasArg()
                     .build();
 
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
             storageOption.setRequired(true);
 
             options.addOption(cliCfgOption);
@@ -590,7 +605,10 @@ public final class ZooKeeperCli extends SubcommandCli {
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
             ZooKeeperClient zkClient = null;
             try {
-                String cliConfigPath = cmd.getOptionValue("cli-config-path");
+                String cliConfigPath = cmd.getOptionValue(
+                        "cli-config-path",
+                        System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+                );
                 CliConfig cliConfig = CliConfig.parseCliConfigFile(cliConfigPath);
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
@@ -649,7 +667,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                     .hasArg()
                     .build();
 
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
             partitionOption.setRequired(true);
             storageOption.setRequired(true);
 
@@ -662,7 +680,10 @@ public final class ZooKeeperCli extends SubcommandCli {
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
             ZooKeeperClient zkClient = null;
             try {
-                String cliConfigPath = cmd.getOptionValue("cli-config-path");
+                String cliConfigPath = cmd.getOptionValue(
+                        "cli-config-path",
+                        System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+                );
                 CliConfig cliConfig = CliConfig.parseCliConfigFile(cliConfigPath);
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
@@ -722,7 +743,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                     .hasArg()
                     .build();
 
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
             partitionOption.setRequired(true);
             storageOption.setRequired(true);
 
@@ -735,7 +756,10 @@ public final class ZooKeeperCli extends SubcommandCli {
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
             ZooKeeperClient zkClient = null;
             try {
-                String cliConfigPath = cmd.getOptionValue("cli-config-path");
+                String cliConfigPath = cmd.getOptionValue(
+                        "cli-config-path",
+                        System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+                );
                 CliConfig cliConfig = CliConfig.parseCliConfigFile(cliConfigPath);
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
@@ -790,7 +814,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                     .hasArg()
                     .build();
 
-            cliCfgOption.setRequired(true);
+            cliCfgOption.setRequired(false);
             groupOption.setRequired(true);
 
             options.addOption(cliCfgOption);
@@ -801,7 +825,10 @@ public final class ZooKeeperCli extends SubcommandCli {
         protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
             ZooKeeperClient zkClient = null;
             try {
-                String cliConfigPath = cmd.getOptionValue("cli-config-path");
+                String cliConfigPath = cmd.getOptionValue(
+                        "cli-config-path",
+                        System.getProperty("waltz.config", "/etc/waltz/waltz.cfg")
+                );
                 CliConfig cliConfig = CliConfig.parseCliConfigFile(cliConfigPath);
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);


### PR DESCRIPTION
Read path to config file from system.properties, defaulting to /etc/waltz/waltz.cfg.  Can still be overridden with --cli-config-path