### PR TITLE
Cleanup demo-bank-app.sh

### DIFF
--- a/bin/demo-bank-app.sh
+++ b/bin/demo-bank-app.sh
@@ -4,14 +4,7 @@ DIR=$(dirname $0)
 
 $DIR/../gradlew --console plain -q copyLibs
 
-CLASSPATH=""
-for file in waltz-demo/build/libs/*.jar;
-do
-    CLASSPATH="$CLASSPATH":"$file"
-done
+export CLASSPATH=$(echo waltz-demo/build/libs/*.jar | tr ' ' :)
+export JAVA_TOOL_OPTIONS=-Dlog4j.configuration=file:config/log4j.properties
 
-JVMOPTS=-Dlog4j.configuration=file:config/log4j.properties
-
-MAINCLASS=com.wepay.waltz.demo.DemoBankApp
-
-java $JVMOPTS -cp ${CLASSPATH#:} $MAINCLASS config/local-docker/demo-app.yml
+java com.wepay.waltz.demo.DemoBankApp config/local-docker/demo-app.yml

--- a/bin/demo-bank-app.sh
+++ b/bin/demo-bank-app.sh
@@ -4,7 +4,12 @@ DIR=$(dirname $0)
 
 $DIR/../gradlew --console plain -q copyLibs
 
-export CLASSPATH=$(echo waltz-demo/build/libs/*.jar | tr ' ' :)
-export JAVA_TOOL_OPTIONS=-Dlog4j.configuration=file:config/log4j.properties
+unset CLASSPATH
+unset JAVA_TOOL_OPTIONS
+CLASSPATH=$(echo waltz-demo/build/libs/*.jar | tr ' ' :)
+JAVA_TOOL_OPTIONS=-Dlog4j.configuration=file:config/log4j.properties
 
-java com.wepay.waltz.demo.DemoBankApp config/local-docker/demo-app.yml
+java \
+	$JAVA_TOOL_OPTIONS \
+	-cp "$CLASSPATH" \
+	com.wepay.waltz.demo.DemoBankApp config/local-docker/demo-app.yml


### PR DESCRIPTION
This is mostly aesthetic.  JAVA_TOOL_OPTIONS is recongnized by the jvm, and there's no need to invoke -cp when CLASSPATH is in the environment.