### PR TITLE
server should unregister partition metrics when unassigned

### DIFF
--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
@@ -125,6 +125,9 @@ public class Partition {
      * stopped successfully..
      */
     public CompletableFuture<Boolean> closeAsync() {
+        // Un-register metrics
+        unregisterMetrics();
+
         if (running.compareAndSet(true, false)) {
             storePartition.close();
 
@@ -146,9 +149,6 @@ public class Partition {
     public void close() {
         CompletableFuture<Boolean> future = closeAsync();
         Uninterruptibly.run(future::get);
-
-        // Un-register metrics
-        unregisterMetrics();
     }
 
     /**


### PR DESCRIPTION
Currently WaltzSever does not unregister partition metrics until shutdown. As the result, a server keep partition metrics after the partition is reassigned to another server.
Metrics were unregistered in `Partition.close()`, but WaltzServer uses `Partition.closeAsync()` when a partition is removed. The fix is to perform unregister in `Partition.closeAsync()`