### PR TITLE
Fixed a bug caused by a race condition in Server.Partition code

### DIFF
--- a/waltz-common/src/main/java/com/wepay/waltz/common/util/QueueConsumerTask.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/util/QueueConsumerTask.java
@@ -14,6 +14,11 @@ public abstract class QueueConsumerTask<E> extends RepeatingTask {
         this.queue = queue;
     }
 
+    /**
+     * Invokes {@link RequestQueue#enqueue(Object)} on the underlying {@link #queue} to enqueue a given item.
+     * @param item an item of type {@link E}
+     * @return {@code true} if enqueue is a success. {@code false} if the underlying queue is closed.
+     */
     public boolean enqueue(E item) {
         return queue.enqueue(item);
     }

--- a/waltz-server/src/test/java/com/wepay/waltz/server/internal/PartitionTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/server/internal/PartitionTest.java
@@ -10,6 +10,7 @@ import com.wepay.waltz.common.message.MountResponse;
 import com.wepay.waltz.common.message.ReqId;
 import com.wepay.waltz.common.util.Utils;
 import com.wepay.waltz.server.WaltzServerConfig;
+import com.wepay.waltz.store.exception.StoreException;
 import com.wepay.waltz.test.mock.MockStore;
 import com.wepay.waltz.test.mock.MockStorePartition;
 import com.wepay.zktools.util.Uninterruptibly;
@@ -562,6 +563,18 @@ public class PartitionTest {
                 partition.close();
             }
         }
+    }
+
+    @Test(expected = PartitionClosedException.class)
+    public void testFlushAppendQueueAlreadyClosed() throws StoreException, PartitionClosedException {
+        Partition partition = new Partition(PARTITION_ID, storePartition, feedCachePartition, fetcher, config);
+        partition.open();
+
+        while (!partition.isClosed()) {
+            partition.close();
+        }
+
+        partition.flushAppendQueue();
     }
 
     private ReqId reqId(int clientId) {


### PR DESCRIPTION
This PR attempts to fix #63 

-- AppendTask#flush immediately throws an exception if it can't enqueue that request.
-- The caller code will verify (sanity check, just in case) that the Partition is indeed closed. If not, logs an error and attempts to close it until success before throwing a PartitionClosedException.