### PR TITLE
update a client high-water mark after db update is committed

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBC.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBC.java
@@ -161,16 +161,17 @@ public abstract class AbstractClientCallbacksForJDBC implements WaltzClientCallb
                                 // Successfully updated the partition's high-water mark. We are holding the write lock.
                                 // Apply the transaction.
                                 applyTransaction(transaction, wrapConnection(connection));
+                                connection.commit();
 
                                 // Update the high-water mark cache
                                 highWaterMark.trySet(transactionId);
+
                             } else {
                                 // Skip this transaction (already applied by some other process)
                                 // Read the high-water mark from database and update the cache.
                                 selectHighWaterMark(partitionId, connection);
+                                connection.commit();
                             }
-
-                            connection.commit();
 
                             return;
 

--- a/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClient.java
@@ -212,6 +212,7 @@ public class WaltzClient {
     /**
      * Gets current high watermark of a partition.
      * @return High watermark of given partition.
+     * @param partitionId the partition id
      */
     public long getHighWaterMark(int partitionId) {
         try {

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/Partition.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/Partition.java
@@ -335,6 +335,7 @@ public class Partition {
      * Sends an append request to the corresponding partition on a Waltz server.
      *
      * @param request the AppendRequest representing payload.
+     * @param context the transaciton context
      * @return a {@link TransactionFuture} which completes when the append response is received.
      */
     public TransactionFuture append(AppendRequest request, TransactionContext context) {

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/TransactionFuture.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/TransactionFuture.java
@@ -19,6 +19,7 @@ public class TransactionFuture extends CompletableFuture<Boolean> {
      * Class Constructor.
      *
      * @param reqId the id of the request.
+     * @param transactionContext the transaction context
      */
     public TransactionFuture(ReqId reqId, TransactionContext transactionContext) {
         this.reqId = reqId;

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/TransactionMonitor.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/TransactionMonitor.java
@@ -135,6 +135,7 @@ public class TransactionMonitor {
      * waits for a maximum of registrationTimeout millis for an existing pending transaction to complete.
      *
      * @param reqId the {@code ReqId} of the transaction.
+     * @param context the transaction context
      * @param registrationTimeout the maximum wait time in millis for registration to complete.
      * @return a {@link TransactionFuture} which will complete when the corresponding transaction is {@link #committed(ReqId)}.
      *         Or, a {@code null}, if {@code registrationTimeout} has passed before registration.


### PR DESCRIPTION
`AbstractClientCallbacksForJDBC` has a client high-water mark cache. The issue is it updates the cache before client db commits. We shouldn't update the cache until commit.

Also fixed some javadocs.