### PR TITLE
use cached client high-water mark for performance

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBC.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBC.java
@@ -97,8 +97,6 @@ public abstract class AbstractClientCallbacksForJDBC implements WaltzClientCallb
             try {
                 Connection connection = dataSource.getConnection();
                 try {
-                    connection.setAutoCommit(true);
-
                     // Read the high-water mark from database and update the cache .
                     return selectHighWaterMark(partitionId, connection);
 

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalStreamClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalStreamClient.java
@@ -90,7 +90,7 @@ public class InternalStreamClient extends InternalBaseClient implements StreamCl
         Partition partition = getPartition(context.partitionId(numPartitions));
         partition.ensureMounted();
 
-        return new TransactionBuilderImpl(partition.nextReqId(), callbacks.getClientHighWaterMark(partition.partitionId));
+        return new TransactionBuilderImpl(partition.nextReqId(), partition.clientHighWaterMark());
     }
 
     /**


### PR DESCRIPTION
This PR improves the performance of `WaltzClient.submit()` using cached client high-water marks instead of calling `getClientHighWaterMark()` callback which reads the high-water mark from an application database.
