### PR TITLE
forbid transaction characteristics change in applyTransaction(txn, conn)

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBC.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBC.java
@@ -5,14 +5,26 @@ import com.wepay.waltz.common.util.BackoffTimer;
 import org.slf4j.Logger;
 
 import javax.sql.DataSource;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 
 /**
  * A sample implementation of client callbacks for applications with a shared database.
@@ -158,7 +170,7 @@ public abstract class AbstractClientCallbacksForJDBC implements WaltzClientCallb
                             if (stmt.getUpdateCount() == 1) {
                                 // Successfully updated the partition's high-water mark. We are holding the write lock.
                                 // Apply the transaction.
-                                applyTransaction(transaction, wrapConnection(connection));
+                                applyTransaction(transaction, new ConnectionWrapper(connection));
                                 connection.commit();
 
                                 // Update the high-water mark cache
@@ -274,27 +286,6 @@ public abstract class AbstractClientCallbacksForJDBC implements WaltzClientCallb
         }
     }
 
-    private Connection wrapConnection(final Connection connection) {
-        return (Connection) Proxy.newProxyInstance(this.getClass().getClassLoader(),
-            new Class[] {
-                Connection.class
-            },
-            new InvocationHandler() {
-                public Object invoke(Object proxy, Method method,
-                                     Object[] args) throws Throwable {
-                    switch (method.getName()) {
-                        case "commit":
-                            throw new SQLException("commit is forbidden");
-                        case "rollback":
-                            throw new SQLException("rollback is forbidden");
-                        default:
-                            return method.invoke(connection, args);
-                    }
-                }
-            }
-        );
-    }
-
     private void closeSafely(PreparedStatement stmt) {
         try {
             stmt.close();
@@ -316,6 +307,295 @@ public abstract class AbstractClientCallbacksForJDBC implements WaltzClientCallb
             connection.close();
         } catch (SQLException ex) {
             // Ignore
+        }
+    }
+
+    public static class ForbiddenJdbcCallException extends SQLException {
+        public final String methodName;
+
+        ForbiddenJdbcCallException(String methodName) {
+            super(methodName + " is forbidden");
+
+            this.methodName = methodName;
+        }
+    }
+
+    private static class ConnectionWrapper implements Connection {
+
+        private final Connection connection;
+
+        ConnectionWrapper(Connection connection) {
+            this.connection = connection;
+        }
+
+        @Override
+        public Statement createStatement() throws SQLException {
+            return connection.createStatement();
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql) throws SQLException {
+            return connection.prepareStatement(sql);
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql) throws SQLException {
+            return connection.prepareCall(sql);
+        }
+
+        @Override
+        public String nativeSQL(String sql) throws SQLException {
+            return connection.nativeSQL(sql);
+        }
+
+        @Override
+        public void setAutoCommit(boolean autoCommit) throws SQLException {
+            throw new ForbiddenJdbcCallException("setAutoCommit");
+        }
+
+        @Override
+        public boolean getAutoCommit() throws SQLException {
+            return connection.getAutoCommit();
+        }
+
+        @Override
+        public void commit() throws SQLException {
+            throw new ForbiddenJdbcCallException("commit");
+        }
+
+        @Override
+        public void rollback() throws SQLException {
+            throw new ForbiddenJdbcCallException("rollback");
+        }
+
+        @Override
+        public void close() throws SQLException {
+            connection.close();
+        }
+
+        @Override
+        public boolean isClosed() throws SQLException {
+            return connection.isClosed();
+        }
+
+        @Override
+        public DatabaseMetaData getMetaData() throws SQLException {
+            return connection.getMetaData();
+        }
+
+        @Override
+        public void setReadOnly(boolean readOnly) throws SQLException {
+            throw new ForbiddenJdbcCallException("setReadOnly");
+        }
+
+        @Override
+        public boolean isReadOnly() throws SQLException {
+            return connection.isReadOnly();
+        }
+
+        @Override
+        public void setCatalog(String catalog) throws SQLException {
+            throw new ForbiddenJdbcCallException("setCatalog");
+        }
+
+        @Override
+        public String getCatalog() throws SQLException {
+            return connection.getCatalog();
+        }
+
+        @Override
+        public void setTransactionIsolation(int level) throws SQLException {
+            throw new ForbiddenJdbcCallException("setTransactionIsolation");
+        }
+
+        @Override
+        public int getTransactionIsolation() throws SQLException {
+            return connection.getTransactionIsolation();
+        }
+
+        @Override
+        public SQLWarning getWarnings() throws SQLException {
+            return connection.getWarnings();
+        }
+
+        @Override
+        public void clearWarnings() throws SQLException {
+            connection.clearWarnings();
+        }
+
+        @Override
+        public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
+            return connection.createStatement(resultSetType, resultSetConcurrency);
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+            return connection.prepareStatement(sql, resultSetType, resultSetConcurrency);
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+            return connection.prepareCall(sql, resultSetType, resultSetConcurrency);
+        }
+
+        @Override
+        public Map<String, Class<?>> getTypeMap() throws SQLException {
+            return connection.getTypeMap();
+        }
+
+        @Override
+        public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+            connection.setTypeMap(map);
+        }
+
+        @Override
+        public void setHoldability(int holdability) throws SQLException {
+            connection.setHoldability(holdability);
+        }
+
+        @Override
+        public int getHoldability() throws SQLException {
+            return connection.getHoldability();
+        }
+
+        @Override
+        public Savepoint setSavepoint() throws SQLException {
+            return connection.setSavepoint();
+        }
+
+        @Override
+        public Savepoint setSavepoint(String name) throws SQLException {
+            return connection.setSavepoint(name);
+        }
+
+        @Override
+        public void rollback(Savepoint savepoint) throws SQLException {
+            connection.rollback(savepoint);
+        }
+
+        @Override
+        public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+            connection.releaseSavepoint(savepoint);
+        }
+
+        @Override
+        public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+            return connection.createStatement(resultSetType, resultSetConcurrency, resultSetHoldability);
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+            return connection.prepareStatement(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+            return connection.prepareCall(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+            return connection.prepareStatement(sql, autoGeneratedKeys);
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+            return connection.prepareStatement(sql, columnIndexes);
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+            return connection.prepareStatement(sql, columnNames);
+        }
+
+        @Override
+        public Clob createClob() throws SQLException {
+            return connection.createClob();
+        }
+
+        @Override
+        public Blob createBlob() throws SQLException {
+            return connection.createBlob();
+        }
+
+        @Override
+        public NClob createNClob() throws SQLException {
+            return connection.createNClob();
+        }
+
+        @Override
+        public SQLXML createSQLXML() throws SQLException {
+            return connection.createSQLXML();
+        }
+
+        @Override
+        public boolean isValid(int timeout) throws SQLException {
+            return connection.isValid(timeout);
+        }
+
+        @Override
+        public void setClientInfo(String name, String value) throws SQLClientInfoException {
+            connection.setClientInfo(name, value);
+        }
+
+        @Override
+        public void setClientInfo(Properties properties) throws SQLClientInfoException {
+            connection.setClientInfo(properties);
+        }
+
+        @Override
+        public String getClientInfo(String name) throws SQLException {
+            return connection.getClientInfo(name);
+        }
+
+        @Override
+        public Properties getClientInfo() throws SQLException {
+            return connection.getClientInfo();
+        }
+
+        @Override
+        public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+            return connection.createArrayOf(typeName, elements);
+        }
+
+        @Override
+        public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+            return connection.createStruct(typeName, attributes);
+        }
+
+        @Override
+        public void setSchema(String schema) throws SQLException {
+            connection.setSchema(schema);
+        }
+
+        @Override
+        public String getSchema() throws SQLException {
+            return connection.getSchema();
+        }
+
+        @Override
+        public void abort(Executor executor) throws SQLException {
+            connection.abort(executor);
+        }
+
+        @Override
+        public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+            connection.setNetworkTimeout(executor, milliseconds);
+        }
+
+        @Override
+        public int getNetworkTimeout() throws SQLException {
+            return connection.getNetworkTimeout();
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            throw new ForbiddenJdbcCallException("unwrap");
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            return connection.isWrapperFor(iface);
         }
     }
 


### PR DESCRIPTION
- stopped using dynamic proxy, and implemented a concrete wrapper class for Connection in AbstractCallbacksForJDBC.
- `setAutoCommit()`, `setTransactionIsolation()` are now forbidden by the wrapper in `AbstractCallbacksForJDBC.applyTransaction(Transaction, Connection)`.
- `setCatalog()`, `setReadOnly()` and `unwrap()` are also forbidden.