### PR TITLE
Minor changes to fix possible port collisions in tests

### DIFF
--- a/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
@@ -59,6 +59,7 @@ public class IntegrationTestHelper {
     private final Path workDir;
     private final String host;
 
+    private PortFinder portFinder;
     private int zkPort;
     private List<Integer> storagePorts = new ArrayList<>();
     private List<Integer> storageAdminPorts = new ArrayList<>();
@@ -110,7 +111,7 @@ public class IntegrationTestHelper {
         this.sslSetup.setConfigParams(props, WaltzServerConfig.SERVER_SSL_CONFIG_PREFIX);
         this.props = props;
 
-        PortFinder portFinder = new PortFinder();
+        this.portFinder = new PortFinder();
         this.zkPort = portFinder.getPort();
         this.serverPort = portFinder.getPort();
         this.serverJettyPort = portFinder.getPort();
@@ -169,6 +170,17 @@ public class IntegrationTestHelper {
             bw.write(yaml.dump(props));
             return filePath;
         }
+    }
+
+    /**
+     * Returns a port using {@link this#portFinder} instance.
+     * If in need of a port, the clients of this class should use this method
+     * instead of another {@link PortFinder} instance to avoid a possible port collision.
+     *
+     * @return a port.
+     */
+    public int getPort() {
+        return portFinder.getPort();
     }
 
     public void startZooKeeperServer() throws Exception {

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/storage/StorageCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/storage/StorageCliTest.java
@@ -446,10 +446,9 @@ public final class StorageCliTest {
 
         helper.startZooKeeperServer();
 
-        PortFinder portFinder = new PortFinder();
-        int destinationPort = portFinder.getPort();
-        int destinationAdminPort = portFinder.getPort();
-        int destinationJettyPort = portFinder.getPort();
+        int destinationPort = helper.getPort();
+        int destinationAdminPort = helper.getPort();
+        int destinationJettyPort = helper.getPort();
         WaltzStorageRunner destinationStorageRunner = helper.getWaltzStorageRunner(destinationPort, destinationAdminPort, destinationJettyPort);
         WaltzStorageRunner sourceStorageRunner = helper.getWaltzStorageRunner();
 


### PR DESCRIPTION
-- We saw an unrelated build failure on https://github.com/wepay/waltz/pull/68 recently.
-- Upon further investigation, we suspect that usage of two different PortFinder instances might be the cause.
-- The reason why the failure isn't deterministic is because PortFinder does a random shuffle on its list of ports.
-- I was able to reproduce it in local multiple times by running StorageCliTest#testRecoverPartition in a loop. Almost always the collision happened between 100th and 200th iteration.