### PR TITLE
Save context on transaction application failure

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/Partition.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/Partition.java
@@ -333,8 +333,10 @@ public class Partition {
                         networkClientCallbacks.onTransactionReceived(transactionId, header, reqId);
 
                     } catch (Throwable ex) {
-                        // Transaction application failed. Save the context for retry.
-                        transactionApplicationFailed.put(reqId, context);
+                        if (context != null) {
+                            // Transaction application failed. Save the context for retry.
+                            transactionApplicationFailed.put(reqId, context);
+                        }
                         throw ex;
                     }
 

--- a/waltz-client/src/test/java/com/wepay/waltz/client/internal/InternalClientTestBase.java
+++ b/waltz-client/src/test/java/com/wepay/waltz/client/internal/InternalClientTestBase.java
@@ -2,6 +2,7 @@ package com.wepay.waltz.client.internal;
 
 import com.wepay.riff.network.ClientSSL;
 import com.wepay.riff.util.PortFinder;
+import com.wepay.waltz.client.WaltzClientCallbacks;
 import com.wepay.waltz.common.util.Utils;
 import com.wepay.waltz.server.WaltzServerConfig;
 import com.wepay.waltz.store.Store;
@@ -84,8 +85,12 @@ public class InternalClientTestBase {
 
     protected MockWaltzClientCallbacks getCallbacks() {
         MockWaltzClientCallbacks callbacks = new MockWaltzClientCallbacks();
-        callbacks.setClientHighWaterMark(0, -1L).setClientHighWaterMark(1, -1L).setClientHighWaterMark(2, -1L);
+        initClientHighWaterMarks(callbacks);
         return callbacks;
+    }
+
+    protected void initClientHighWaterMarks(MockWaltzClientCallbacks callbacks) {
+        callbacks.setClientHighWaterMark(0, -1L).setClientHighWaterMark(1, -1L).setClientHighWaterMark(2, -1L);
     }
 
     protected InternalRpcClient getInternalRpcClient(int maxConcurrentTransactions) {
@@ -99,8 +104,22 @@ public class InternalClientTestBase {
         return internalRpcClient;
     }
 
-    protected InternalStreamClient getInternalStreamClient(boolean autoMount, int maxConcurrentTransactions, InternalRpcClient rpcClient) {
-        InternalStreamClient internalStreamClient = new InternalStreamClient(autoMount, clientSslCtx, maxConcurrentTransactions, getCallbacks(), rpcClient, null);
+    protected InternalStreamClient getInternalStreamClient(
+        boolean autoMount,
+        int maxConcurrentTransactions,
+        InternalRpcClient rpcClient
+    ) {
+        return getInternalStreamClient(autoMount, maxConcurrentTransactions, rpcClient, getCallbacks());
+    }
+
+    protected InternalStreamClient getInternalStreamClient(
+        boolean autoMount,
+        int maxConcurrentTransactions,
+        InternalRpcClient rpcClient,
+        WaltzClientCallbacks callbacks
+    ) {
+        InternalStreamClient internalStreamClient =
+            new InternalStreamClient(autoMount, clientSslCtx, maxConcurrentTransactions, callbacks, rpcClient, null);
         clients.add(internalStreamClient);
 
         internalStreamClient.setClientId(clientId.incrementAndGet());


### PR DESCRIPTION
This PR fixes a bug that Waltz client fails to invoke `TransactionContext.onApplication()` callback when `WaltzClientCallbacks.applyTransaction(Transaction)` failed with an exception.
The problem was that `TransactionContext` is removed from `TransactionMonitor` after commit and we no longer have the context when the retry is attempted.
The fix saves TransactionContext in a map (`ReqId` -> `TransactionContext`) when `applyTransaction()` failed. A subsequent successful retry can look up the map to recover the transaction context and invoke `onApplication()`.