### PR TITLE
Use a separate ClassLoader for ServerCliTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -381,6 +381,7 @@ project(':waltz-test') {
             project(':waltz-storage'),
             project(':waltz-tools'),
 
+            "junit:junit:$junitVersion",
             "com.wepay.zktools:zktools:$zkToolsVersion",
             "io.netty:netty-all:$nettyVersion"
         )

--- a/waltz-test/src/main/java/com/wepay/waltz/test/util/SeparateClassLoaderJUnitRunner.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/util/SeparateClassLoaderJUnitRunner.java
@@ -1,0 +1,63 @@
+package com.wepay.waltz.test.util;
+
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+
+import java.net.URLClassLoader;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+public class SeparateClassLoaderJUnitRunner extends Runner {
+
+    private final Runner inner;
+
+    public SeparateClassLoaderJUnitRunner(Class<?> clazz) throws InitializationError {
+        try {
+            ClassLoader classLoader = AccessController.doPrivileged(
+                (PrivilegedAction<ClassLoader>) SeparateClassLoader::new
+            );
+            this.inner = getRunner(classLoader.loadClass(clazz.getName()));
+
+        } catch (InitializationError ex) {
+            throw ex;
+
+        } catch (Throwable ex) {
+            throw new InitializationError(ex);
+        }
+    }
+
+    @Override
+    public Description getDescription() {
+        return inner.getDescription();
+    }
+
+    @Override
+    public void run(RunNotifier notifier) {
+        inner.run(notifier);
+    }
+
+    private Runner getRunner(Class<?> clazz) throws InitializationError {
+        return new BlockJUnit4ClassRunner(clazz);
+    }
+
+    private static class SeparateClassLoader extends URLClassLoader {
+
+        SeparateClassLoader() {
+            super(((URLClassLoader) getSystemClassLoader()).getURLs());
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (name.startsWith("com.wepay.")) {
+                return super.findClass(name);
+
+            } else {
+                return super.loadClass(name);
+            }
+        }
+    }
+
+}

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/server/ServerCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/server/ServerCliTest.java
@@ -1,9 +1,11 @@
 package com.wepay.waltz.tools.server;
 
 import com.wepay.waltz.test.util.IntegrationTestHelper;
+import com.wepay.waltz.test.util.SeparateClassLoaderJUnitRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -12,6 +14,7 @@ import java.util.Properties;
 
 import static junit.framework.TestCase.assertTrue;
 
+@RunWith(SeparateClassLoaderJUnitRunner.class)
 public final class ServerCliTest {
 
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();


### PR DESCRIPTION
A temporary fix for ServerCliTest failure due to the common metrics registry.