### PR TITLE
updating the version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.waltz
 sourceCompatibility=1.8
-version=0.4.4
+version=0.5.0


### PR DESCRIPTION
Bumping up the version before releasing the artifact.
Compared to the previous version `0.4.4`, this version contains the new append lock feature