### PR TITLE
Minor javadoc fix to make the gradle task happy

### DIFF
--- a/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
@@ -173,7 +173,7 @@ public class IntegrationTestHelper {
     }
 
     /**
-     * Returns a port using {@link this#portFinder} instance.
+     * Returns a port using {@link IntegrationTestHelper#portFinder} instance.
      * If in need of a port, the clients of this class should use this method
      * instead of another {@link PortFinder} instance to avoid a possible port collision.
      *


### PR DESCRIPTION
The task `./gradlew waltz-test:javadoc` is failing with the following error 

```
waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java:176: error: unexpected text
     * Returns a port using {@link this#portFinder} instance.
```

Seems like javadoc in current version doesn't like `this#<field>` notation.

Fixing it by changing that.