### PR TITLE
Avoid possible NPE in StoreMetadata#removePartition

### DIFF
--- a/waltz-common/src/main/java/com/wepay/waltz/common/metadata/StoreMetadata.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/metadata/StoreMetadata.java
@@ -373,6 +373,13 @@ public class StoreMetadata {
 
             final NodeData<GroupDescriptor> groupNodeData = session.getGroupDescriptorNodeData();
             Map<String, Integer> groups = groupNodeData.value.groups;
+
+            if (!groups.containsKey(storage)) {
+                throw new IllegalArgumentException(
+                    String.format("Storage node %s is not part of any of the storage groups", storage)
+                );
+            }
+
             int groupToValidate = groups.get(storage);
 
             // create a newReplicas excluding partition to remove


### PR DESCRIPTION
-- Avoid NPE by verifying that the given storage node belongs to one of the existing groups.
-- Previously, if we execute the command with a non-existent storage node, it was causing NPE because groups.get(...) would return null that gets assigned to primitive int.
-- Throwing a specific exception helps fix the command quickly.

-- Verified in local that the intended log message is printed to the console.