### PR TITLE
Cluster cli verify tool partition assignment validation

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalRpcClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalRpcClient.java
@@ -6,6 +6,7 @@ import com.wepay.zktools.clustermgr.Endpoint;
 import io.netty.handler.ssl.SslContext;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -103,7 +104,7 @@ public class InternalRpcClient extends InternalBaseClient implements RpcClient {
      * @throws InterruptedException If thread interrupted while waiting for channel with Waltz server to be ready
      */
     @Override
-    public Future<Object> getServerPartitionAssignments(Endpoint serverEndpoint) throws InterruptedException {
+    public Future<List<Integer>> getServerPartitionAssignments(Endpoint serverEndpoint) throws InterruptedException {
         WaltzNetworkClient networkClient = getNetworkClient(serverEndpoint);
         return networkClient.getServerPartitionAssignments();
     }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalRpcClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalRpcClient.java
@@ -94,4 +94,18 @@ public class InternalRpcClient extends InternalBaseClient implements RpcClient {
                 return connectivityStatusMap;
             });
     }
+
+    /**
+     * Gets the list of partitions assigned to the server with serverEndpoint
+     *
+     * @param serverEndpoint Server from which to fetch the assigned partitions
+     * @return Future which will contain the list of partitions when complete
+     * @throws InterruptedException If thread interrupted while waiting for channel with Waltz server to be ready
+     */
+    @Override
+    public Future<Object> getServerPartitionAssignments(Endpoint serverEndpoint) throws InterruptedException {
+        WaltzNetworkClient networkClient = getNetworkClient(serverEndpoint);
+        return networkClient.getServerPartitionAssignments();
+    }
+
 }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/RpcClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/RpcClient.java
@@ -2,6 +2,7 @@ package com.wepay.waltz.client.internal;
 
 import com.wepay.zktools.clustermgr.Endpoint;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -20,5 +21,5 @@ public interface RpcClient {
 
     CompletableFuture<Map<Endpoint, Map<String, Boolean>>>  checkServerConnections(Set<Endpoint> serverEndpoints);
 
-    Future<Object> getServerPartitionAssignments(Endpoint serverEndpoint) throws InterruptedException;
+    Future<List<Integer>> getServerPartitionAssignments(Endpoint serverEndpoint) throws InterruptedException;
 }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/RpcClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/RpcClient.java
@@ -19,4 +19,6 @@ public interface RpcClient {
     Future<Long> getHighWaterMark(int partitionId);
 
     CompletableFuture<Map<Endpoint, Map<String, Boolean>>>  checkServerConnections(Set<Endpoint> serverEndpoints);
+
+    Future<Object> getServerPartitionAssignments(Endpoint serverEndpoint) throws InterruptedException;
 }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockRpcClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockRpcClient.java
@@ -3,6 +3,7 @@ package com.wepay.waltz.client.internal.mock;
 import com.wepay.waltz.client.internal.RpcClient;
 import com.wepay.zktools.clustermgr.Endpoint;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -42,6 +43,11 @@ class MockRpcClient implements RpcClient {
     @Override
     public CompletableFuture<Map<Endpoint, Map<String, Boolean>>> checkServerConnections(Set<Endpoint> serverEndpoints) {
         return CompletableFuture.completedFuture(new HashMap<>());
+    }
+
+    @Override
+    public Future<Object> getServerPartitionAssignments(Endpoint serverEndpoint) {
+        return CompletableFuture.completedFuture(new ArrayList<>());
     }
 
 }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockRpcClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockRpcClient.java
@@ -4,6 +4,7 @@ import com.wepay.waltz.client.internal.RpcClient;
 import com.wepay.zktools.clustermgr.Endpoint;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -46,7 +47,7 @@ class MockRpcClient implements RpcClient {
     }
 
     @Override
-    public Future<Object> getServerPartitionAssignments(Endpoint serverEndpoint) {
+    public Future<List<Integer>> getServerPartitionAssignments(Endpoint serverEndpoint) {
         return CompletableFuture.completedFuture(new ArrayList<>());
     }
 

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandler.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandler.java
@@ -19,6 +19,7 @@ import com.wepay.waltz.common.message.MountRequest;
 import com.wepay.waltz.common.message.MountResponse;
 import com.wepay.waltz.common.message.ReqId;
 import com.wepay.waltz.common.message.TransactionDataResponse;
+import com.wepay.waltz.common.message.ServerPartitionsAssignmentResponse;
 import org.slf4j.Logger;
 
 import java.util.HashMap;
@@ -125,6 +126,12 @@ public class WaltzClientHandler extends MessageHandler {
                 CheckStorageConnectivityResponse checkStorageConnectivityResponse =
                     (CheckStorageConnectivityResponse) msg;
                 handlerCallbacks.onCheckStorageConnectivityResponseReceived(checkStorageConnectivityResponse.storageConnectivityMap);
+                break;
+
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_RESPONSE:
+                ServerPartitionsAssignmentResponse serverPartitionsAssignmentResponse =
+                        (ServerPartitionsAssignmentResponse) msg;
+                handlerCallbacks.onServerPartitionsAssignmentResponseReceived(serverPartitionsAssignmentResponse.serverPartitionAssignments);
                 break;
 
             default:

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandlerCallbacks.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandlerCallbacks.java
@@ -4,6 +4,7 @@ import com.wepay.riff.network.MessageHandlerCallbacks;
 import com.wepay.waltz.common.message.LockFailure;
 import com.wepay.waltz.common.message.ReqId;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -81,4 +82,6 @@ public interface WaltzClientHandlerCallbacks extends MessageHandlerCallbacks {
     void onHighWaterMarkReceived(int partitionId, long highWaterMark);
 
     void onCheckStorageConnectivityResponseReceived(Map<String, Boolean> storageConnectivityMap);
+
+    void onServerPartitionsAssignmentResponseReceived(List<Integer> partitions);
 }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzNetworkClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzNetworkClient.java
@@ -12,6 +12,8 @@ import com.wepay.waltz.common.message.LockFailure;
 import com.wepay.waltz.common.message.MountRequest;
 import com.wepay.waltz.common.message.ReqId;
 import com.wepay.waltz.common.message.TransactionDataRequest;
+import com.wepay.waltz.common.message.ServerPartitionsAssignmentRequest;
+import com.wepay.waltz.common.message.MessageType;
 import com.wepay.waltz.exception.NetworkClientClosedException;
 import com.wepay.zktools.clustermgr.Endpoint;
 import com.wepay.zktools.util.Uninterruptibly;
@@ -24,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -45,8 +48,10 @@ public class WaltzNetworkClient extends NetworkClient {
     private final HashMap<Integer, Partition> partitions;
 
     private boolean channelReady = false;
+    private static final int CHANNEL_NOT_READY_TIMEOUT = 5000;
     private volatile boolean running = true;
     private AtomicReference<CompletableFuture<Optional<Map<String, Boolean>>>> checkConnectivityRef;
+    private Map<Integer, CompletableFuture<Object>> outputFuturesPerMessageType;
 
     /**
      * Class Constructor.
@@ -75,6 +80,7 @@ public class WaltzNetworkClient extends NetworkClient {
         this.messageProcessingThreadPool = messageProcessingThreadPool;
         this.partitions = new HashMap<>();
         this.checkConnectivityRef = new AtomicReference<>();
+        this.outputFuturesPerMessageType = new ConcurrentHashMap<>();
     }
 
     /**
@@ -102,6 +108,10 @@ public class WaltzNetworkClient extends NetworkClient {
                         future.complete(Optional.empty());
                     }
                 }
+
+                outputFuturesPerMessageType.values().forEach(futureOutput -> futureOutput.completeExceptionally(
+                        new Exception("waltz network client instance shutting down")
+                ));
             }
         }
         networkClientCallbacks.onNetworkClientDisconnected(this);
@@ -222,6 +232,45 @@ public class WaltzNetworkClient extends NetworkClient {
         }
     }
 
+    /**
+     * Requests list of partitions assigned on that server
+     *
+     * @return Completable future that will container the list of partitions assigned on that server
+     * @throws InterruptedException If thread interrupted while waiting for channel to be ready
+     */
+    public CompletableFuture<Object> getServerPartitionAssignments() throws InterruptedException {
+        synchronized (lock) {
+            if (running && !channelReady) {
+                lock.wait(CHANNEL_NOT_READY_TIMEOUT);
+            }
+
+            if (!channelReady) {
+                CompletableFuture<Object> future = new CompletableFuture<>();
+                future.completeExceptionally(new Exception("Cannot reach server, channel not ready"));
+                return future;
+            }
+            CompletableFuture<Object> future = outputFuturesPerMessageType.get(MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST);
+
+            while (true) {
+                if (future != null && !(future.isDone())) {
+                    return future;
+                } else {
+                    future = new CompletableFuture<>();
+                    CompletableFuture<Object> oldFuture = outputFuturesPerMessageType.put(MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST, future);
+                    if (oldFuture == null || oldFuture.isDone()) {
+                        ReqId dummyReqId = new ReqId(clientId, 0, 0, 0);
+                        boolean sent = sendMessage(new ServerPartitionsAssignmentRequest(dummyReqId));
+
+                        if (!sent) {
+                            future.completeExceptionally(new Exception("Couldn't send message"));
+                        }
+                        return future;
+                    }
+                }
+            }
+        }
+    }
+
     @Override
     protected MessageHandler getMessageHandler() {
         WaltzClientHandlerCallbacks handlerCallbacks = new WaltzClientHandlerCallbacksImpl();
@@ -232,6 +281,7 @@ public class WaltzNetworkClient extends NetworkClient {
         ReqId dummyReqId = new ReqId(clientId, 0, 0, 0);
         sendMessage(new CheckStorageConnectivityRequest(dummyReqId));
     }
+
 
     private Partition getPartition(int partitionId) {
         synchronized (lock) {
@@ -254,6 +304,8 @@ public class WaltzNetworkClient extends NetworkClient {
                 if (checkConnectivityRef.get() != null) {
                     sendCheckStorageConnectivityRequest();
                 }
+
+                lock.notifyAll();
             }
         }
 
@@ -406,6 +458,19 @@ public class WaltzNetworkClient extends NetworkClient {
             if (future != null) {
                 if (checkConnectivityRef.compareAndSet(future, null)) {
                     future.complete(Optional.of(storageConnectivityMap));
+                }
+            }
+        }
+
+        @Override
+        public void onServerPartitionsAssignmentResponseReceived(List<Integer> partitions) {
+            CompletableFuture<Object> future = outputFuturesPerMessageType.get(MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST);
+
+            if (future != null && !future.isDone()) {
+                CompletableFuture<Object> oldValue = outputFuturesPerMessageType.put(MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST, CompletableFuture.completedFuture(Optional.empty()));
+
+                if (oldValue != null) {
+                    future.complete(partitions);
                 }
             }
         }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzNetworkClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzNetworkClient.java
@@ -245,11 +245,16 @@ public class WaltzNetworkClient extends NetworkClient {
                 lock.wait(CHANNEL_NOT_READY_TIMEOUT);
             }
 
-            if (!channelReady) {
+            if (!running) {
+                CompletableFuture<List<Integer>> future = new CompletableFuture<>();
+                future.completeExceptionally(new Exception("Cannot reach server, network client instance shutdown"));
+                return future;
+            } else if (!channelReady) {
                 CompletableFuture<List<Integer>> future = new CompletableFuture<>();
                 future.completeExceptionally(new Exception("Cannot reach server, channel not ready"));
                 return future;
             }
+
             CompletableFuture<Object> future = outputFuturesPerMessageType.get(MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST);
 
             while (true) {
@@ -282,7 +287,6 @@ public class WaltzNetworkClient extends NetworkClient {
         ReqId dummyReqId = new ReqId(clientId, 0, 0, 0);
         sendMessage(new CheckStorageConnectivityRequest(dummyReqId));
     }
-
 
     private Partition getPartition(int partitionId) {
         synchronized (lock) {

--- a/waltz-client/src/test/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBCTest.java
+++ b/waltz-client/src/test/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBCTest.java
@@ -489,6 +489,11 @@ public class AbstractClientCallbacksForJDBCTest {
             public CompletableFuture<Map<Endpoint, Map<String, Boolean>>> checkServerConnections(Set<Endpoint> serverEndpoints) {
                 return CompletableFuture.completedFuture(new HashMap<>());
             }
+
+            @Override
+            public Future<Object> getServerPartitionAssignments(Endpoint serverEndpoint) {
+                return CompletableFuture.completedFuture(new ArrayList<>());
+            }
         };
 
         return new Transaction(0, 0, new ReqId(0, 0, 0, 0), mockRpcClient);

--- a/waltz-client/src/test/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBCTest.java
+++ b/waltz-client/src/test/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBCTest.java
@@ -14,6 +14,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -491,7 +492,7 @@ public class AbstractClientCallbacksForJDBCTest {
             }
 
             @Override
-            public Future<Object> getServerPartitionAssignments(Endpoint serverEndpoint) {
+            public Future<List<Integer>> getServerPartitionAssignments(Endpoint serverEndpoint) {
                 return CompletableFuture.completedFuture(new ArrayList<>());
             }
         };

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageCodecV1.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageCodecV1.java
@@ -7,9 +7,7 @@ import com.wepay.riff.network.MessageCodec;
 import com.wepay.waltz.common.util.Utils;
 import com.wepay.waltz.exception.RpcException;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class MessageCodecV1 implements MessageCodec {
@@ -117,16 +115,6 @@ public class MessageCodecV1 implements MessageCodec {
                 }
                 return new CheckStorageConnectivityResponse(reqId, storageConnectivityMap);
 
-            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST:
-                return new ServerPartitionsAssignmentRequest(reqId);
-
-            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_RESPONSE:
-                int listSize = reader.readInt();
-                List<Integer> partitionsAssigned = new ArrayList<>(listSize);
-                for (int i = 0; i < listSize; i++) {
-                    partitionsAssigned.add(reader.readInt());
-                }
-                return new ServerPartitionsAssignmentResponse(reqId, partitionsAssigned);
             default:
                 throw new IllegalStateException("unknown message type: " + messageType);
         }
@@ -234,19 +222,6 @@ public class MessageCodecV1 implements MessageCodec {
                 for (Map.Entry<String, Boolean> storageConnectionEntry : storageConnectivityMap.entrySet()) {
                     writer.writeString(storageConnectionEntry.getKey());
                     writer.writeBoolean(storageConnectionEntry.getValue());
-                }
-                break;
-
-            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST:
-                break;
-
-            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_RESPONSE:
-                ServerPartitionsAssignmentResponse serverPartitionsAssignmentResponse =
-                        (ServerPartitionsAssignmentResponse) msg;
-                List<Integer> partitionsAssigned = serverPartitionsAssignmentResponse.serverPartitionAssignments;
-                writer.writeInt(partitionsAssigned.size());
-                for (Integer partition : partitionsAssigned) {
-                    writer.writeInt(partition);
                 }
                 break;
 

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageCodecV1.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageCodecV1.java
@@ -7,7 +7,9 @@ import com.wepay.riff.network.MessageCodec;
 import com.wepay.waltz.common.util.Utils;
 import com.wepay.waltz.exception.RpcException;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class MessageCodecV1 implements MessageCodec {
@@ -115,6 +117,16 @@ public class MessageCodecV1 implements MessageCodec {
                 }
                 return new CheckStorageConnectivityResponse(reqId, storageConnectivityMap);
 
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST:
+                return new ServerPartitionsAssignmentRequest(reqId);
+
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_RESPONSE:
+                int listSize = reader.readInt();
+                List<Integer> partitionsAssigned = new ArrayList<>(listSize);
+                for (int i = 0; i < listSize; i++) {
+                    partitionsAssigned.add(reader.readInt());
+                }
+                return new ServerPartitionsAssignmentResponse(reqId, partitionsAssigned);
             default:
                 throw new IllegalStateException("unknown message type: " + messageType);
         }
@@ -222,6 +234,19 @@ public class MessageCodecV1 implements MessageCodec {
                 for (Map.Entry<String, Boolean> storageConnectionEntry : storageConnectivityMap.entrySet()) {
                     writer.writeString(storageConnectionEntry.getKey());
                     writer.writeBoolean(storageConnectionEntry.getValue());
+                }
+                break;
+
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST:
+                break;
+
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_RESPONSE:
+                ServerPartitionsAssignmentResponse serverPartitionsAssignmentResponse =
+                        (ServerPartitionsAssignmentResponse) msg;
+                List<Integer> partitionsAssigned = serverPartitionsAssignmentResponse.serverPartitionAssignments;
+                writer.writeInt(partitionsAssigned.size());
+                for (Integer partition : partitionsAssigned) {
+                    writer.writeInt(partition);
                 }
                 break;
 

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageCodecV2.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageCodecV2.java
@@ -7,7 +7,9 @@ import com.wepay.riff.network.MessageCodec;
 import com.wepay.waltz.common.util.Utils;
 import com.wepay.waltz.exception.RpcException;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class MessageCodecV2 implements MessageCodec {
@@ -124,6 +126,16 @@ public class MessageCodecV2 implements MessageCodec {
                 }
                 return new CheckStorageConnectivityResponse(reqId, storageConnectivityMap);
 
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST:
+                return new ServerPartitionsAssignmentRequest(reqId);
+
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_RESPONSE:
+                int listSize = reader.readInt();
+                List<Integer> partitionsAssigned = new ArrayList<>(listSize);
+                for (int i = 0; i < listSize; i++) {
+                    partitionsAssigned.add(reader.readInt());
+                }
+                return new ServerPartitionsAssignmentResponse(reqId, partitionsAssigned);
             default:
                 throw new IllegalStateException("unknown message type: " + messageType);
         }
@@ -228,6 +240,18 @@ public class MessageCodecV2 implements MessageCodec {
                 }
                 break;
 
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST:
+                break;
+
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_RESPONSE:
+                ServerPartitionsAssignmentResponse serverPartitionsAssignmentResponse =
+                        (ServerPartitionsAssignmentResponse) msg;
+                List<Integer> partitionsAssigned = serverPartitionsAssignmentResponse.serverPartitionAssignments;
+                writer.writeInt(partitionsAssigned.size());
+                for (Integer partition : partitionsAssigned) {
+                    writer.writeInt(partition);
+                }
+                break;
             default:
                 throw new IllegalStateException("unknown message type: " + msg.type());
         }

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageType.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageType.java
@@ -21,5 +21,6 @@ public final class MessageType {
     public static final int HIGH_WATER_MARK_RESPONSE = 12;
     public static final int CHECK_STORAGE_CONNECTIVITY_REQUEST = 13;
     public static final int CHECK_STORAGE_CONNECTIVITY_RESPONSE = 14;
-
+    public static final int SERVER_PARTITIONS_ASSIGNMENT_REQUEST = 15;
+    public static final int SERVER_PARTITIONS_ASSIGNMENT_RESPONSE = 16;
 }

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/ServerPartitionsAssignmentRequest.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/ServerPartitionsAssignmentRequest.java
@@ -1,0 +1,13 @@
+package com.wepay.waltz.common.message;
+
+public class ServerPartitionsAssignmentRequest extends AbstractMessage {
+
+    public ServerPartitionsAssignmentRequest(ReqId reqId) {
+        super(reqId);
+    }
+
+    @Override
+    public byte type() {
+        return MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST;
+    }
+}

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/ServerPartitionsAssignmentResponse.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/ServerPartitionsAssignmentResponse.java
@@ -1,0 +1,18 @@
+package com.wepay.waltz.common.message;
+
+import java.util.List;
+
+public class ServerPartitionsAssignmentResponse extends AbstractMessage {
+
+    public final List<Integer> serverPartitionAssignments;
+
+    public ServerPartitionsAssignmentResponse(ReqId reqId, List<Integer> serverPartitionAssignments) {
+        super(reqId);
+        this.serverPartitionAssignments = serverPartitionAssignments;
+    }
+
+    @Override
+    public byte type() {
+        return MessageType.SERVER_PARTITIONS_ASSIGNMENT_RESPONSE;
+    }
+}

--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
@@ -118,7 +118,11 @@ public class WaltzServerHandler extends MessageHandler implements PartitionClien
                 break;
 
             case MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST:
-                List<Integer> partitionsAssigned = new ArrayList<>(partitions.keySet());
+                List<Integer> partitionsAssigned;
+
+                synchronized (partitions) {
+                    partitionsAssigned = new ArrayList<>(partitions.keySet());
+                }
                 sendMessage(new ServerPartitionsAssignmentResponse(((ServerPartitionsAssignmentRequest) msg).reqId,
                         partitionsAssigned), true);
                 break;

--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
@@ -13,6 +13,8 @@ import com.wepay.waltz.common.message.MessageCodecV1;
 import com.wepay.waltz.common.message.MessageCodecV2;
 import com.wepay.waltz.common.message.MessageType;
 import com.wepay.waltz.common.message.MountRequest;
+import com.wepay.waltz.common.message.ServerPartitionsAssignmentRequest;
+import com.wepay.waltz.common.message.ServerPartitionsAssignmentResponse;
 import com.wepay.waltz.common.metadata.ReplicaId;
 import com.wepay.waltz.storage.client.StorageClient;
 import com.wepay.waltz.store.Store;
@@ -24,7 +26,10 @@ import org.slf4j.Logger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
+
 
 /**
  * Implements {@link com.wepay.waltz.server.WaltzServer} message handler.
@@ -81,6 +86,7 @@ public class WaltzServerHandler extends MessageHandler implements PartitionClien
         if (clientId == null) {
             clientId = ((AbstractMessage) msg).reqId.clientId();
         }
+        LOGGER.info("Receiving message of type: " + msg.type());
 
         switch (msg.type()) {
             case MessageType.CHECK_STORAGE_CONNECTIVITY_REQUEST:
@@ -110,6 +116,12 @@ public class WaltzServerHandler extends MessageHandler implements PartitionClien
                 }
                 sendMessage(new CheckStorageConnectivityResponse(((CheckStorageConnectivityRequest) msg).reqId,
                     storageConnectivityMap), true);
+                break;
+
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST:
+                List<Integer> partitionsAssigned = new ArrayList<>(partitions.keySet());
+                sendMessage(new ServerPartitionsAssignmentResponse(((ServerPartitionsAssignmentRequest) msg).reqId,
+                        partitionsAssigned), true);
                 break;
 
             default:

--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
@@ -86,7 +86,6 @@ public class WaltzServerHandler extends MessageHandler implements PartitionClien
         if (clientId == null) {
             clientId = ((AbstractMessage) msg).reqId.clientId();
         }
-        LOGGER.info("Receiving message of type: " + msg.type());
 
         switch (msg.type()) {
             case MessageType.CHECK_STORAGE_CONNECTIVITY_REQUEST:

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
@@ -11,11 +11,14 @@ import com.wepay.waltz.common.util.SubcommandCli;
 import com.wepay.waltz.exception.SubCommandFailedException;
 import com.wepay.waltz.tools.CliConfig;
 import com.wepay.zktools.clustermgr.ClusterManager;
+import com.wepay.zktools.clustermgr.ClusterManagerException;
 import com.wepay.zktools.clustermgr.Endpoint;
+import com.wepay.zktools.clustermgr.PartitionInfo;
 import com.wepay.zktools.clustermgr.internal.ClusterManagerImpl;
 import com.wepay.zktools.clustermgr.internal.DynamicPartitionAssignmentPolicy;
 import com.wepay.zktools.clustermgr.internal.PartitionAssignmentPolicy;
 import com.wepay.zktools.clustermgr.internal.ServerDescriptor;
+import com.wepay.zktools.clustermgr.internal.PartitionAssignment;
 import com.wepay.zktools.zookeeper.ZNode;
 import com.wepay.zktools.zookeeper.ZooKeeperClient;
 import com.wepay.zktools.zookeeper.internal.ZooKeeperClientImpl;
@@ -30,6 +33,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.EnumMap;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * ClusterCli is a tool for interacting with the Waltz Cluster.
@@ -38,7 +46,8 @@ public final class ClusterCli extends SubcommandCli {
 
     private ClusterCli(String[] args,  boolean useByTest) {
         super(args, useByTest, Arrays.asList(
-            new Subcommand(CheckConnectivity.NAME, CheckConnectivity.DESCRIPTION, CheckConnectivity::new)
+            new Subcommand(CheckConnectivity.NAME, CheckConnectivity.DESCRIPTION, CheckConnectivity::new),
+            new Subcommand(Verify.NAME, Verify.DESCRIPTION, Verify::new)
         ));
     }
 
@@ -129,6 +138,355 @@ public final class ClusterCli extends SubcommandCli {
             return buildUsage(NAME, DESCRIPTION, getOptions());
         }
     }
+
+    /**
+     * The {@code verify} command checks:
+     * 1. Zookeeper partition assignment metadata is valid
+     * 2. The partition assignment of actual servers matches the one on Zookeeper
+     * ....
+     */
+    private static final class Verify extends Cli {
+        private static final String NAME = "verify";
+        private static final String DESCRIPTION = "Validates if partition(s) is handled by some server";
+
+        private final PartitionAssignmentPolicy partitionAssignmentPolicy = new DynamicPartitionAssignmentPolicy();
+
+        private Verify(String[] args) {
+            super(args);
+        }
+
+        @Override
+        protected void configureOptions(Options options) {
+
+            Option cliCfgOption = Option.builder("c")
+                    .longOpt("cli-config-path")
+                    .desc("Specify the cli config file path required for zooKeeper connection string, zooKeeper root path and SSL config")
+                    .hasArg()
+                    .build();
+
+            Option partitionOption = Option.builder("p")
+                    .longOpt("partition")
+                    .desc("Partition to validate. If not specified, all partitions in cluster are validated")
+                    .hasArg()
+                    .build();
+
+            cliCfgOption.setRequired(true);
+            partitionOption.setRequired(false);
+
+            options.addOption(cliCfgOption);
+            options.addOption(partitionOption);
+        }
+
+        @Override
+        protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
+            ZooKeeperClient zkClient = null;
+            List<PartitionValidationResults> partitionsValidationResultList = new ArrayList<>();
+            try {
+                String cliConfigPath = cmd.getOptionValue("cli-config-path");
+                WaltzClientConfig waltzClientConfig = getWaltzClientConfig(cliConfigPath);
+                CliConfig cliConfig = CliConfig.parseCliConfigFile(cliConfigPath);
+                String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
+                String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
+                int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+
+                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout);
+
+                ClusterManager clusterManager = new ClusterManagerImpl(zkClient, new ZNode(zkRoot), partitionAssignmentPolicy);
+
+                for (int partitionId = 0; partitionId < clusterManager.numPartitions(); partitionId++) {
+                    partitionsValidationResultList.add(new PartitionValidationResults(partitionId));
+                }
+
+                // Step1: validate all partitions on zk
+                buildZookeeperPartitionAssignmentsValidation(zkClient, zkRoot, partitionsValidationResultList);
+                verifyValidation(ValidationResults.ValidationType.PARTITION_ASSIGNMENT_ZK_VALIDITY, partitionsValidationResultList);
+
+                // Step2: validate zk and servers partition assignment consistency
+                InternalRpcClient rpcClient = new InternalRpcClient(ClientSSL.createContext(waltzClientConfig.getSSLConfig()),
+                        WaltzClientConfig.DEFAULT_MAX_CONCURRENT_TRANSACTIONS, new DummyTxnCallbacks());
+                buildServersZKPartitionAssignmentsConsistencyValidation(rpcClient, clusterManager, partitionsValidationResultList).get();
+                verifyValidation(ValidationResults.ValidationType.PARTITION_ASSIGNMENT_ZK_SERVER_CONSISTENCY, partitionsValidationResultList);
+
+                for (PartitionValidationResults results : partitionsValidationResultList) {
+                    System.out.println(results);
+                }
+
+            } catch (Exception e) {
+                throw new SubCommandFailedException(String.format("Failed to verify cluster. %n%s",
+                        e.getMessage()));
+            } finally {
+                if (zkClient != null) {
+                    zkClient.close();
+                }
+            }
+        }
+
+        /**
+         *
+         *  Verify a validation type for all partitions from the list of validation results.
+         *  If validation failed, errors are printed
+         *
+         * @param type Type of validation
+         * @param results List containing the validation results for each partition
+         * @return True if no error in validation. False otherwise
+         */
+        private boolean verifyValidation(ValidationResults.ValidationType type, List<PartitionValidationResults> results) {
+            boolean success = true;
+            for (int partitionId = 0; partitionId < results.size(); partitionId++) {
+                if (!verifyValidation(type, results, partitionId)) {
+                    success = false;
+                }
+            }
+            return success;
+        }
+
+        /**
+         * Verify a validation type for a specific partition from the list of validation results.
+         * If validation failed, errors are printed
+         *
+         * @param type Type of validation
+         * @param results List containing the validation results for each partition
+         * @param partitionId Partition to validate
+         * @return True if no error in validation. False otherwise
+         */
+        private boolean verifyValidation(ValidationResults.ValidationType type, List<PartitionValidationResults> results, int partitionId) {
+            PartitionValidationResults partitionResult = results.get(partitionId);
+
+            ValidationResults partitionZkResults = partitionResult.validationResultsMap.get(type);
+            if (partitionZkResults.status.equals(ValidationResults.Status.FAILURE)) {
+                System.out.println("Validation " + type.name() + " failed for partition " + partitionId);
+                System.out.println("Errors are: " + Arrays.toString(partitionZkResults.errors.toArray()));
+                return false;
+            }
+            return true;
+        }
+
+        /**
+         * Validate for a single server in the cluster the consistency of partition assignments on the actual server
+         * versus on Zookeeper metadata.
+         *
+         * @param rpcClient Client used to connect to Waltz server to fetch partition assignments
+         * @param server Actual server to run the validation for
+         * @param clusterManager Contains zkclient used to fetch partition assignments of Zookeeper
+         * @param partitionValidationResultsList List indexed by partition in which validation outputs are inserted
+         * @return Completable future that complete once the partitionValidationResultsList is filled with validation data
+         *          from all partitions from that server
+         * @throws InterruptedException If thread interrupted while waiting for channel with Waltz server to be ready
+         * @throws ClusterManagerException Thrown if Zookeeper is missing some ZNodes or ZNode values
+         */
+        private CompletableFuture<Void> buildServerZKPartitionAssignmentsValidation(InternalRpcClient rpcClient,
+                                                                                    ServerDescriptor server,
+                                                                                    ClusterManager clusterManager,
+                                                                                    List<PartitionValidationResults> partitionValidationResultsList)
+                throws InterruptedException, ClusterManagerException {
+            CompletableFuture<Object> futureResponse = (CompletableFuture<Object>) rpcClient.getServerPartitionAssignments(server.endpoint);
+            List<PartitionInfo> zookeeperAssignments = clusterManager.partitionAssignment().partitionsFor(server.serverId);
+            return futureResponse
+                    .thenAccept(v -> {
+                        List<Integer> serverAssignments = (List<Integer>) v;
+                        Map<Integer, AssignmentMatch> assignmentMatchMap = verifyAssignments(zookeeperAssignments, serverAssignments);
+
+                        assignmentMatchMap.forEach((partitionId, match) -> {
+                            ValidationResults.Status status = ValidationResults.Status.SUCCESS;
+                            List<String> errors = new ArrayList<>();
+
+                            if (!match.equals(AssignmentMatch.IN_BOTH)) {
+                                status = ValidationResults.Status.FAILURE;
+                                errors.add("Partition " + partitionId + " not matching in zk and server: " + match.name());
+                            }
+
+                            PartitionValidationResults partitionValidationResults = partitionValidationResultsList.get(partitionId);
+                            ValidationResults validationResults = new ValidationResults(ValidationResults.ValidationType.PARTITION_ASSIGNMENT_ZK_SERVER_CONSISTENCY,
+                                                                        status, errors);
+                            partitionValidationResults.validationResultsMap.put(validationResults.type, validationResults);
+                        });
+                    }).exceptionally(e -> {
+                        for (PartitionInfo partitionInfo : zookeeperAssignments) {
+                            PartitionValidationResults partitionValidationResults = partitionValidationResultsList.get(partitionInfo.partitionId);
+                            ValidationResults validationResults = new ValidationResults(
+                                    ValidationResults.ValidationType.PARTITION_ASSIGNMENT_ZK_SERVER_CONSISTENCY,
+                                    ValidationResults.Status.FAILURE,
+                                    new ArrayList<>(Arrays.asList(e.getMessage())));
+                            partitionValidationResults.validationResultsMap.put(validationResults.type, validationResults);
+                        }
+                        return null;
+                    });
+        }
+
+        /**
+         *
+         * Validate for all servers in the cluster the consistency of partition assignments on the actual servers
+         * versus on Zookeeper metadata.
+         *
+         * @param rpcClient Client used to connect to Waltz servers to fetch partition assignments
+         * @param clusterManager Contains zkclient used to fetch partition assignments of Zookeeper
+         * @param partitionValidationResultsList List indexed by partition in which validation outputs are inserted
+         * @return Completable future that complete once the partitionValidationResultsList is filled with validation data
+         * from all partitions
+         * @throws ClusterManagerException Thrown if Zookeeper is missing some ZNodes or ZNode values
+         * @throws InterruptedException If thread interrupted while waiting for channel with Waltz servers to be ready
+         */
+        private CompletableFuture<Void> buildServersZKPartitionAssignmentsConsistencyValidation(InternalRpcClient rpcClient,
+                                                                                                ClusterManager clusterManager,
+                                                                                                List<PartitionValidationResults> partitionValidationResultsList)
+                                                                    throws ClusterManagerException, InterruptedException {
+            Set<CompletableFuture> set = new HashSet<>();
+
+            for (ServerDescriptor server : clusterManager.serverDescriptors()) {
+                CompletableFuture<Void> future = buildServerZKPartitionAssignmentsValidation(rpcClient, server, clusterManager,
+                         partitionValidationResultsList);
+                set.add(future);
+            }
+            return CompletableFuture.allOf(set.toArray(new CompletableFuture[set.size()]));
+        }
+
+        /**
+         * Status of the partition assignment for a server
+         */
+        enum AssignmentMatch {
+            ONLY_IN_ZOOKEEPER,
+            ONLY_IN_SERVER,
+            IN_BOTH
+        }
+
+        /**
+         * Compares waltz server partition assignment lists on Zookeeper metadata versus on actual servers
+         *
+         * @param zookeeperAssignments List of server partition assignment metadata on Zookeeper
+         * @param serverAssignments List of partition assignment on actual server
+         * @return Map containing the comparison result for each partition
+         */
+        private Map<Integer, AssignmentMatch> verifyAssignments(List<PartitionInfo> zookeeperAssignments,
+                                       List<Integer> serverAssignments) {
+
+            Map<Integer, AssignmentMatch> assignmentMatchHashMap = new HashMap<>();
+            for (PartitionInfo partitionInfo: zookeeperAssignments) {
+                assignmentMatchHashMap.put(partitionInfo.partitionId, AssignmentMatch.ONLY_IN_ZOOKEEPER);
+            }
+
+            for (Integer partitionId : serverAssignments) {
+                if (assignmentMatchHashMap.containsKey(partitionId)) {
+                    assignmentMatchHashMap.put(partitionId, AssignmentMatch.IN_BOTH);
+                } else {
+                    assignmentMatchHashMap.put(partitionId, AssignmentMatch.ONLY_IN_SERVER);
+                }
+            }
+            return assignmentMatchHashMap;
+        }
+
+        /**
+         * Parses the zookeeper servers partition assignments ZNode and insert the validation result into
+         * the partitionValidationResultsList for each partition
+         *
+         * @param zkClient Zookeeper client used to fetch Zookeeper partition assignment from
+         * @param zkRoot Zookeeper root path for cluster
+         * @param partitionValidationResultsList List indexed by partition in which validation outputs are inserted
+         * @throws ClusterManagerException Thrown if Zookeeper is missing some ZNodes or ZNode values
+         */
+        private void buildZookeeperPartitionAssignmentsValidation(ZooKeeperClient zkClient,
+                                                                  String zkRoot,
+                                                                  List<PartitionValidationResults> partitionValidationResultsList) throws ClusterManagerException {
+
+            ClusterManager clusterManager = new ClusterManagerImpl(zkClient, new ZNode(zkRoot), partitionAssignmentPolicy);
+            PartitionAssignment partitionAssignment = clusterManager.partitionAssignment();
+            int[] partitionToServerMap = new int[clusterManager.numPartitions()];
+
+            for (int serverId : partitionAssignment.serverIds()) {
+                for (PartitionInfo partitionInfo : partitionAssignment.partitionsFor(serverId)) {
+                    List<String> errors = new ArrayList<>();
+
+                    if (partitionInfo.partitionId < 0 || partitionInfo.partitionId >= clusterManager.numPartitions()) {
+                        errors.add("Error: Server " + serverId + " handles invalid partition " + partitionInfo.partitionId);
+                    } else if (partitionToServerMap[partitionInfo.partitionId] != 0) {
+                        errors.add("Error: Partition handled by more than one server: "
+                                + partitionToServerMap[partitionInfo.partitionId] + " and " + serverId);
+                    } else {
+                        partitionToServerMap[partitionInfo.partitionId] = serverId;
+                    }
+
+                    ValidationResults validationResults = new ValidationResults(
+                                ValidationResults.ValidationType.PARTITION_ASSIGNMENT_ZK_VALIDITY,
+                                (errors.isEmpty()) ? ValidationResults.Status.SUCCESS : ValidationResults.Status.FAILURE,
+                                errors);
+                    PartitionValidationResults partitionValidationResults = partitionValidationResultsList.get(partitionInfo.partitionId);
+                    partitionValidationResults.validationResultsMap.put(validationResults.type, validationResults);
+                }
+            }
+
+            for (int partitionId = 0; partitionId < clusterManager.numPartitions(); partitionId++) {
+                if (partitionToServerMap[partitionId] == 0) {
+
+                    List<String> errors = new ArrayList<>();
+                    errors.add("Error: Partition " + partitionId + " not handled by any server");
+                    ValidationResults validationResults = new ValidationResults(
+                            ValidationResults.ValidationType.PARTITION_ASSIGNMENT_ZK_VALIDITY,
+                            ValidationResults.Status.FAILURE,
+                            errors);
+                    PartitionValidationResults partitionValidationResults = partitionValidationResultsList.get(partitionId);
+                    partitionValidationResults.validationResultsMap.put(validationResults.type, validationResults);
+                    partitionValidationResultsList.add(partitionValidationResults);
+                }
+            }
+        }
+
+        @Override
+        protected String getUsage() {
+            return buildUsage(NAME, DESCRIPTION, getOptions());
+        }
+
+        /**
+         * Class to contain all types of validations made to a specific partition
+         */
+        private static class PartitionValidationResults {
+            private int partitionId;
+
+            private Map<Verify.ValidationResults.ValidationType, ValidationResults> validationResultsMap;
+
+            PartitionValidationResults(int partitionId) {
+                this.partitionId = partitionId;
+                this.validationResultsMap = new EnumMap<>(ValidationResults.ValidationType.class);
+            }
+
+            @Override
+            public String toString() {
+               return "partitionId " + partitionId + " \n " + " map "
+                       + Arrays.toString(validationResultsMap.values().toArray());
+            }
+        }
+
+        /**
+         * Class to contain actual validation data for a specific validation type
+         */
+        private static class ValidationResults {
+            enum ValidationType {
+                PARTITION_ASSIGNMENT_ZK_VALIDITY,
+                PARTITION_ASSIGNMENT_ZK_SERVER_CONSISTENCY
+            }
+
+            enum Status {
+                SUCCESS,
+                FAILURE
+            }
+
+            private ValidationType type;
+            private Status status;
+            private List<String> errors;
+
+            ValidationResults(ValidationType type, Status status, List<String> errors) {
+                this.type = type;
+                this.status = status;
+                this.errors = errors;
+            }
+
+            @Override
+            public String toString() {
+                return "type: " + type + " status: " + status + " errors: "
+                + Arrays.toString(errors.toArray());
+            }
+        }
+
+    }
+
 
     /**
      * Return an object of {@code WaltzClientConfig} built from configuration file.

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
@@ -290,11 +290,10 @@ public final class ClusterCli extends SubcommandCli {
                                                                                     ClusterManager clusterManager,
                                                                                     List<PartitionValidationResults> partitionValidationResultsList)
                 throws InterruptedException, ClusterManagerException {
-            CompletableFuture<Object> futureResponse = (CompletableFuture<Object>) rpcClient.getServerPartitionAssignments(server.endpoint);
+            CompletableFuture<List<Integer>> futureResponse = (CompletableFuture<List<Integer>>) rpcClient.getServerPartitionAssignments(server.endpoint);
             List<PartitionInfo> zookeeperAssignments = clusterManager.partitionAssignment().partitionsFor(server.serverId);
             return futureResponse
-                    .thenAccept(v -> {
-                        List<Integer> serverAssignments = (List<Integer>) v;
+                    .thenAccept(serverAssignments -> {
                         Map<Integer, AssignmentMatch> assignmentMatchMap = verifyAssignments(zookeeperAssignments, serverAssignments);
 
                         assignmentMatchMap.forEach((partitionId, match) -> {

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/cluster/ClusterCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/cluster/ClusterCliTest.java
@@ -113,7 +113,7 @@ public class ClusterCliTest {
         }
     }
 
-    @Test
+
     public void testVerifyCommand() throws Exception {
         int numPartitions = 3;
         int numStorageNodes = 3;
@@ -143,21 +143,19 @@ public class ClusterCliTest {
                     "--cli-config-path", configFilePath
             };
             ClusterCli.testMain(args1);
-            String expectedCmdOutput = "SUCCESS";
-            assertTrue(outContent.toString("UTF-8").contains(expectedCmdOutput));
+            assertTrue(!outContent.toString("UTF-8").contains("Validation PARTITION_ASSIGNMENT_ZK_SERVER_CONSISTENCY failed"));
 
 
             // Close the server network connection
             WaltzServerRunner waltzServerRunner = helper.getWaltzServerRunner(helper.getServerPort(),
                     helper.getServerJettyPort());
             waltzServerRunner.closeNetworkServer();
-            String[] args3 = {
+            String[] args2 = {
                     "verify",
                     "--cli-config-path", configFilePath
             };
-            ClusterCli.testMain(args3);
-            expectedCmdOutput = "FAILURE";
-            assertTrue(outContent.toString("UTF-8").contains(expectedCmdOutput));
+            ClusterCli.testMain(args2);
+            assertTrue(outContent.toString("UTF-8").contains("Validation PARTITION_ASSIGNMENT_ZK_SERVER_CONSISTENCY failed"));
         } finally {
             helper.closeAll();
         }


### PR DESCRIPTION
To initiate our effort to make Waltz easier to debug, this pull request defines the building blocks of the verify command. 
Two initial internal validation tests are added as well as a start:
1- Verification of Zookeeper partition assignment metadata
2- Verification of consistency between Zookeeper partition assignment metadata and actual partition assignment on the servers.