### PR TITLE
Fix to add/remove preferred partitions to/from WaltzServer via ServerCli

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ project.ext {
     slf4jVersion = '1.7.25'
     mockitoVersion = '1.9.5'
     assertjVersion = '3.8.0'
-    zkToolsVersion = '0.5.0'
+    zkToolsVersion = '0.6.0'
     yamlVersion = '1.20'
     riffVersion = '2.4.3'
     jacksonVersion = '2.9.6'

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalRpcClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalRpcClient.java
@@ -109,4 +109,32 @@ public class InternalRpcClient extends InternalBaseClient implements RpcClient {
         return networkClient.getServerPartitionAssignments();
     }
 
+    /**
+     * Adds the given partition Id as a preferred partition to the given Server Endpoint.
+     * @param serverEndpoint Server Endpoint to add the partition to.
+     * @param partitionId The partition Id.
+     * @return a Completable future that has a Boolean status. True if the preferred partition is added, otherwise
+     * false.
+     * @throws InterruptedException If thread is interrupted while waiting for Network client channel to be ready.
+     */
+    @Override
+    public CompletableFuture<Boolean> addPreferredPartition(Endpoint serverEndpoint, int partitionId) throws InterruptedException {
+        WaltzNetworkClient networkClient = getNetworkClient(serverEndpoint);
+        return networkClient.addPreferredPartition(partitionId);
+    }
+
+    /**
+     * Removes the given partition Id as a preferred partition from the given Server Endpoint.
+     * @param serverEndpoint Server Endpoint from which the partition is to be removed.
+     * @param partitionId The partition Id.
+     * @return a Completable future that has a Boolean status. True if the preferred partition is removed, otherwise
+     * false.
+     * @throws InterruptedException If thread is interrupted while waiting for Network client channel to be ready.
+     */
+    @Override
+    public CompletableFuture<Boolean> removePreferredPartition(Endpoint serverEndpoint, int partitionId) throws InterruptedException {
+        WaltzNetworkClient networkClient = getNetworkClient(serverEndpoint);
+        return networkClient.removePreferredPartition(partitionId);
+    }
+
 }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/RpcClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/RpcClient.java
@@ -22,4 +22,8 @@ public interface RpcClient {
     CompletableFuture<Map<Endpoint, Map<String, Boolean>>>  checkServerConnections(Set<Endpoint> serverEndpoints);
 
     Future<List<Integer>> getServerPartitionAssignments(Endpoint serverEndpoint) throws InterruptedException;
+
+    CompletableFuture<Boolean> addPreferredPartition(Endpoint serverEndpoint, int partitionId) throws InterruptedException;
+
+    CompletableFuture<Boolean> removePreferredPartition(Endpoint serverEndpoint, int partitionId) throws InterruptedException;
 }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockRpcClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockRpcClient.java
@@ -51,4 +51,14 @@ class MockRpcClient implements RpcClient {
         return CompletableFuture.completedFuture(new ArrayList<>());
     }
 
+    @Override
+    public CompletableFuture<Boolean> addPreferredPartition(Endpoint serverEndpoint, int partitionId) throws InterruptedException {
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> removePreferredPartition(Endpoint serverEndpoint, int partitionId) throws InterruptedException {
+        return CompletableFuture.completedFuture(true);
+
+    }
 }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandler.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandler.java
@@ -6,6 +6,7 @@ import com.wepay.riff.network.MessageHandler;
 import com.wepay.riff.network.MessageProcessingThreadPool;
 import com.wepay.riff.util.Logging;
 import com.wepay.waltz.common.message.AbstractMessage;
+import com.wepay.waltz.common.message.AddPreferredPartitionResponse;
 import com.wepay.waltz.common.message.CheckStorageConnectivityResponse;
 import com.wepay.waltz.common.message.FeedData;
 import com.wepay.waltz.common.message.FlushResponse;
@@ -17,6 +18,7 @@ import com.wepay.waltz.common.message.MessageCodecV2;
 import com.wepay.waltz.common.message.MessageType;
 import com.wepay.waltz.common.message.MountRequest;
 import com.wepay.waltz.common.message.MountResponse;
+import com.wepay.waltz.common.message.RemovePreferredPartitionResponse;
 import com.wepay.waltz.common.message.ReqId;
 import com.wepay.waltz.common.message.TransactionDataResponse;
 import com.wepay.waltz.common.message.ServerPartitionsAssignmentResponse;
@@ -132,6 +134,17 @@ public class WaltzClientHandler extends MessageHandler {
                 ServerPartitionsAssignmentResponse serverPartitionsAssignmentResponse =
                         (ServerPartitionsAssignmentResponse) msg;
                 handlerCallbacks.onServerPartitionsAssignmentResponseReceived(serverPartitionsAssignmentResponse.serverPartitionAssignments);
+                break;
+
+            case MessageType.ADD_PREFERRED_PARTITION_RESPONSE:
+                AddPreferredPartitionResponse addPreferredPartitionResponse =  (AddPreferredPartitionResponse) msg;
+                handlerCallbacks.onAddPreferredPartitionResponseReceived(addPreferredPartitionResponse.result);
+                break;
+
+            case MessageType.REMOVE_PREFERRED_PARTITION_RESPONSE:
+                RemovePreferredPartitionResponse removePreferredPartitionResponse =
+                    (RemovePreferredPartitionResponse) msg;
+                handlerCallbacks.onRemovePreferredPartitionResponseReceived(removePreferredPartitionResponse.result);
                 break;
 
             default:

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandlerCallbacks.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandlerCallbacks.java
@@ -84,4 +84,9 @@ public interface WaltzClientHandlerCallbacks extends MessageHandlerCallbacks {
     void onCheckStorageConnectivityResponseReceived(Map<String, Boolean> storageConnectivityMap);
 
     void onServerPartitionsAssignmentResponseReceived(List<Integer> partitions);
+
+    void onAddPreferredPartitionResponseReceived(Boolean result);
+
+    void onRemovePreferredPartitionResponseReceived(Boolean result);
+
 }

--- a/waltz-client/src/test/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBCTest.java
+++ b/waltz-client/src/test/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBCTest.java
@@ -495,6 +495,16 @@ public class AbstractClientCallbacksForJDBCTest {
             public Future<List<Integer>> getServerPartitionAssignments(Endpoint serverEndpoint) {
                 return CompletableFuture.completedFuture(new ArrayList<>());
             }
+
+            @Override
+            public CompletableFuture<Boolean> addPreferredPartition(Endpoint serverEndpoint, int partitionId) throws InterruptedException {
+                return CompletableFuture.completedFuture(true);
+            }
+
+            @Override
+            public CompletableFuture<Boolean> removePreferredPartition(Endpoint serverEndpoint, int partitionId) throws InterruptedException {
+                return CompletableFuture.completedFuture(true);
+            }
         };
 
         return new Transaction(0, 0, new ReqId(0, 0, 0, 0), mockRpcClient);

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/AddPreferredPartitionRequest.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/AddPreferredPartitionRequest.java
@@ -1,0 +1,15 @@
+package com.wepay.waltz.common.message;
+
+public class AddPreferredPartitionRequest extends AbstractMessage {
+
+    public final int partitionId;
+    public AddPreferredPartitionRequest(ReqId reqId, int partitionId) {
+        super(reqId);
+        this.partitionId = partitionId;
+    }
+
+    @Override
+    public byte type() {
+        return MessageType.ADD_PREFERRED_PARTITION_REQUEST;
+    }
+}

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/AddPreferredPartitionResponse.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/AddPreferredPartitionResponse.java
@@ -1,0 +1,15 @@
+package com.wepay.waltz.common.message;
+
+public class AddPreferredPartitionResponse extends AbstractMessage {
+
+    public final Boolean result;
+    public AddPreferredPartitionResponse(ReqId reqId, boolean result) {
+        super(reqId);
+        this.result = result;
+    }
+
+    @Override
+    public byte type() {
+        return MessageType.ADD_PREFERRED_PARTITION_RESPONSE;
+    }
+}

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageCodecV2.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageCodecV2.java
@@ -38,6 +38,8 @@ public class MessageCodecV2 implements MessageCodec {
         int header;
         byte[] data;
         int checksum;
+        int partitionId;
+        boolean result;
 
         switch (messageType) {
             case MessageType.MOUNT_REQUEST:
@@ -136,6 +138,23 @@ public class MessageCodecV2 implements MessageCodec {
                     partitionsAssigned.add(reader.readInt());
                 }
                 return new ServerPartitionsAssignmentResponse(reqId, partitionsAssigned);
+
+            case MessageType.ADD_PREFERRED_PARTITION_REQUEST:
+                partitionId = reader.readInt();
+                return new AddPreferredPartitionRequest(reqId, partitionId);
+
+            case MessageType.ADD_PREFERRED_PARTITION_RESPONSE:
+                result = reader.readBoolean();
+                return new AddPreferredPartitionResponse(reqId, result);
+
+            case MessageType.REMOVE_PREFERRED_PARTITION_REQUEST:
+                partitionId = reader.readInt();
+                return new RemovePreferredPartitionRequest(reqId, partitionId);
+
+            case MessageType.REMOVE_PREFERRED_PARTITION_RESPONSE:
+                result = reader.readBoolean();
+                return new RemovePreferredPartitionResponse(reqId, result);
+
             default:
                 throw new IllegalStateException("unknown message type: " + messageType);
         }
@@ -252,6 +271,28 @@ public class MessageCodecV2 implements MessageCodec {
                     writer.writeInt(partition);
                 }
                 break;
+
+            case MessageType.ADD_PREFERRED_PARTITION_REQUEST:
+                AddPreferredPartitionRequest addPreferredPartitionRequest = (AddPreferredPartitionRequest) msg;
+                writer.writeInt(addPreferredPartitionRequest.partitionId);
+                break;
+
+            case MessageType.ADD_PREFERRED_PARTITION_RESPONSE:
+                AddPreferredPartitionResponse addPreferredPartitionResponse = (AddPreferredPartitionResponse) msg;
+                writer.writeBoolean(addPreferredPartitionResponse.result);
+                break;
+
+            case MessageType.REMOVE_PREFERRED_PARTITION_REQUEST:
+                RemovePreferredPartitionRequest removePreferredPartitionRequest = (RemovePreferredPartitionRequest) msg;
+                writer.writeInt(removePreferredPartitionRequest.partitionId);
+                break;
+
+            case MessageType.REMOVE_PREFERRED_PARTITION_RESPONSE:
+                RemovePreferredPartitionResponse removePreferredPartitionResponse =
+                    (RemovePreferredPartitionResponse) msg;
+                writer.writeBoolean(removePreferredPartitionResponse.result);
+                break;
+
             default:
                 throw new IllegalStateException("unknown message type: " + msg.type());
         }

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageType.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageType.java
@@ -23,4 +23,9 @@ public final class MessageType {
     public static final int CHECK_STORAGE_CONNECTIVITY_RESPONSE = 14;
     public static final int SERVER_PARTITIONS_ASSIGNMENT_REQUEST = 15;
     public static final int SERVER_PARTITIONS_ASSIGNMENT_RESPONSE = 16;
+    public static final int ADD_PREFERRED_PARTITION_REQUEST = 17;
+    public static final int ADD_PREFERRED_PARTITION_RESPONSE = 18;
+    public static final int REMOVE_PREFERRED_PARTITION_REQUEST = 19;
+    public static final int REMOVE_PREFERRED_PARTITION_RESPONSE = 20;
+
 }

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/RemovePreferredPartitionRequest.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/RemovePreferredPartitionRequest.java
@@ -1,0 +1,16 @@
+package com.wepay.waltz.common.message;
+
+public class RemovePreferredPartitionRequest extends AbstractMessage {
+
+    public final int partitionId;
+
+    public RemovePreferredPartitionRequest(ReqId reqId, int partitionId) {
+        super(reqId);
+        this.partitionId = partitionId;
+    }
+
+    @Override
+    public byte type() {
+        return MessageType.REMOVE_PREFERRED_PARTITION_REQUEST;
+    }
+}

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/RemovePreferredPartitionResponse.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/RemovePreferredPartitionResponse.java
@@ -1,0 +1,15 @@
+package com.wepay.waltz.common.message;
+
+public class RemovePreferredPartitionResponse extends AbstractMessage {
+
+    public final Boolean result;
+    public RemovePreferredPartitionResponse(ReqId reqId, boolean result) {
+        super(reqId);
+        this.result = result;
+    }
+
+    @Override
+    public byte type() {
+        return MessageType.REMOVE_PREFERRED_PARTITION_RESPONSE;
+    }
+}

--- a/waltz-test/src/main/java/com/wepay/waltz/test/util/WaltzServerRunner.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/util/WaltzServerRunner.java
@@ -12,13 +12,17 @@ import com.wepay.zktools.clustermgr.ClusterManagerException;
 import com.wepay.zktools.clustermgr.PartitionInfo;
 import com.wepay.zktools.clustermgr.internal.ClusterManagerImpl;
 import com.wepay.zktools.clustermgr.internal.DynamicPartitionAssignmentPolicy;
+import com.wepay.zktools.clustermgr.internal.PartitionAssignment;
 import com.wepay.zktools.clustermgr.internal.PartitionAssignmentPolicy;
+import com.wepay.zktools.clustermgr.internal.ServerDescriptor;
 import com.wepay.zktools.zookeeper.ZNode;
 import com.wepay.zktools.zookeeper.ZooKeeperClient;
 import com.wepay.zktools.zookeeper.ZooKeeperClientException;
 import com.wepay.zktools.zookeeper.internal.ZooKeeperClientImpl;
 import io.netty.handler.ssl.SslContext;
 import org.slf4j.Logger;
+
+import java.util.Set;
 
 public class WaltzServerRunner extends Runner<WaltzServer> {
 
@@ -122,5 +126,13 @@ public class WaltzServerRunner extends Runner<WaltzServer> {
         } catch (Exception ex) {
             logger.error("failed to close the network server", ex);
         }
+    }
+
+    public Set<ServerDescriptor> getServerDescriptors() throws ClusterManagerException {
+        return this.clusterManager.serverDescriptors();
+    }
+
+    public PartitionAssignment getPartitionAssignment() throws ClusterManagerException {
+        return this.clusterManager.partitionAssignment();
     }
 }

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/server/ServerCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/server/ServerCli.java
@@ -3,14 +3,24 @@ package com.wepay.waltz.tools.server;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wepay.riff.network.ClientSSL;
+import com.wepay.waltz.client.Transaction;
+import com.wepay.waltz.client.WaltzClient;
+import com.wepay.waltz.client.WaltzClientCallbacks;
+import com.wepay.waltz.client.WaltzClientConfig;
+import com.wepay.waltz.client.internal.InternalRpcClient;
 import com.wepay.waltz.common.util.Cli;
 import com.wepay.waltz.common.util.SubcommandCli;
 import com.wepay.waltz.exception.SubCommandFailedException;
+import com.wepay.zktools.clustermgr.Endpoint;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.http.client.fluent.Request;
+import org.yaml.snakeyaml.Yaml;
 
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -23,7 +33,11 @@ public final class ServerCli extends SubcommandCli {
 
     private ServerCli(String[] args, boolean useByTest) {
         super(args, useByTest, Arrays.asList(
-                new Subcommand(ServerCli.ListPartition.NAME, ListPartition.DESCRIPTION, ServerCli.ListPartition::new)
+            new Subcommand(ServerCli.ListPartition.NAME, ListPartition.DESCRIPTION, ServerCli.ListPartition::new),
+            new Subcommand(AddPreferredPartition.NAME, AddPreferredPartition.DESCRIPTION,
+                ServerCli.AddPreferredPartition::new),
+            new Subcommand(RemovePreferredPartition.NAME, RemovePreferredPartition.DESCRIPTION,
+                ServerCli.RemovePreferredPartition::new)
         ));
     }
 
@@ -123,6 +137,219 @@ public final class ServerCli extends SubcommandCli {
                 sb.append(String.format("Storage node for partition %d: %s%n", partitionId, storageNode));
             }
             System.out.println(sb.toString());
+        }
+    }
+
+    /**
+     * The {@code AddPreferredPartition} command adds the given preferred partition to the given server.
+     */
+    private static final class AddPreferredPartition extends Cli {
+        protected static final String NAME = "add-preferred-partition";
+        protected static final String DESCRIPTION = "add a preferred partition to the server.";
+
+        protected AddPreferredPartition(String[] args) {
+            super(args);
+        }
+
+        @Override
+        protected void configureOptions(Options options) {
+            Option serverOption = Option.builder("s")
+                .longOpt("server")
+                .desc("Specify server in format of host:port, where port is the server port")
+                .hasArg()
+                .build();
+            Option partitionOption = Option.builder("p")
+                .longOpt("partition")
+                .desc("Specify the preferred partition to be added to the given server")
+                .hasArg()
+                .build();
+            Option cliCfgOption = Option.builder("c")
+                .longOpt("cli-config-path")
+                .desc("Specify the cli config file path required for ZooKeeper connection string, ZooKeeper root path and SSL config")
+                .hasArg()
+                .build();
+            serverOption.setRequired(true);
+            partitionOption.setRequired(true);
+            cliCfgOption.setRequired(true);
+
+            options.addOption(serverOption);
+            options.addOption(partitionOption);
+            options.addOption(cliCfgOption);
+        }
+
+        @Override
+        protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
+            String hostAndPort = cmd.getOptionValue("server");
+            String partitionId = cmd.getOptionValue("partition");
+            String cliConfigPath = cmd.getOptionValue("cli-config-path");
+
+            try {
+                String[] hostAndPortArray = hostAndPort.split(":");
+                if (hostAndPortArray.length != 2) {
+                    throw new IllegalArgumentException("Http must be in format of host:port");
+                }
+                String host = hostAndPortArray[0];
+                int serverPort = Integer.parseInt(hostAndPortArray[1]);
+
+                if (!partitionId.matches("^[0-9]+$")) {
+                    throw new IllegalArgumentException(String.format("Partition id '%s' is invalid. Expected a non-negative integer", partitionId));
+                }
+                addPreferredPartition(host, serverPort, Integer.parseInt(partitionId), cliConfigPath);
+            } catch (Exception e) {
+                throw new SubCommandFailedException(String.format("Failed to add preferred partition .%n%s", e));
+            }
+        }
+
+        private void addPreferredPartition(String host, int serverPort, int partitionId, String cliConfigPath) throws Exception {
+            Endpoint serverEndpoint = new Endpoint(host, serverPort);
+            InternalRpcClient rpcClient = null;
+            try {
+                WaltzClientConfig waltzClientConfig = getWaltzClientConfig(cliConfigPath);
+                DummyTxnCallbacks callbacks = new DummyTxnCallbacks();
+                rpcClient = new InternalRpcClient(ClientSSL.createContext(waltzClientConfig.getSSLConfig()),
+                    WaltzClientConfig.DEFAULT_MAX_CONCURRENT_TRANSACTIONS, callbacks);
+
+                if (!(Boolean) rpcClient.addPreferredPartition(serverEndpoint, partitionId).get()) {
+                    System.out.println("Failed to add preferred partition " + partitionId + " to server Endpoint "
+                            + serverEndpoint + ".");
+                }
+            } catch (Exception e) {
+                throw new SubCommandFailedException(String.format("Failed to add preferred partition %s to the "
+                    + "server Endpoint %s. %n%s ", partitionId, serverEndpoint.toString(), e));
+            } finally {
+                if (rpcClient != null) {
+                    rpcClient.close();
+                }
+            }
+        }
+
+        @Override
+        protected String getUsage() {
+            return buildUsage(NAME, DESCRIPTION, getOptions());
+        }
+    }
+
+    /**
+     * The {@code RemovePreferredPartition} command removes the given preferred partition from the given server.
+     */
+    private static final class RemovePreferredPartition extends Cli {
+        protected static final String NAME = "remove-preferred-partition";
+        protected static final String DESCRIPTION = "Remove a preferred partition from the server.";
+
+        protected RemovePreferredPartition(String[] args) {
+            super(args);
+        }
+
+        @Override
+        protected void configureOptions(Options options) {
+            Option serverOption = Option.builder("s")
+                .longOpt("server")
+                .desc("Specify server in format of host:port, where port is the server port")
+                .hasArg()
+                .build();
+            Option partitionOption = Option.builder("p")
+                .longOpt("partition")
+                .desc("Specify the preferred partition to be removed from the given server")
+                .hasArg()
+                .build();
+            Option cliCfgOption = Option.builder("c")
+                .longOpt("cli-config-path")
+                .desc("Specify the cli config file path required for ZooKeeper connection string, ZooKeeper root path and SSL config")
+                .hasArg()
+                .build();
+            serverOption.setRequired(true);
+            partitionOption.setRequired(true);
+            cliCfgOption.setRequired(true);
+
+            options.addOption(serverOption);
+            options.addOption(partitionOption);
+            options.addOption(cliCfgOption);
+        }
+
+        @Override
+        protected void processCmd(CommandLine cmd) throws SubCommandFailedException {
+            String hostAndPort = cmd.getOptionValue("server");
+            String partitionId = cmd.getOptionValue("partition");
+            String cliConfigPath = cmd.getOptionValue("cli-config-path");
+
+            try {
+                String[] hostAndPortArray = hostAndPort.split(":");
+                if (hostAndPortArray.length != 2) {
+                    throw new IllegalArgumentException("Http must be in format of host:port");
+                }
+                String host = hostAndPortArray[0];
+                int serverPort = Integer.parseInt(hostAndPortArray[1]);
+
+                if (!partitionId.matches("^[0-9]+$")) {
+                    throw new IllegalArgumentException(String.format("Partition id '%s' is invalid. Expected a non-negative integer", partitionId));
+                }
+                removePreferredPartition(host, serverPort, Integer.parseInt(partitionId), cliConfigPath);
+            } catch (Exception e) {
+                throw new SubCommandFailedException(String.format("Failed to remove preferred partition .%n%s", e));
+            }
+        }
+
+        private void removePreferredPartition(String host, int serverPort, int partitionId, String cliConfigPath) throws Exception {
+            Endpoint serverEndpoint = new Endpoint(host, serverPort);
+            InternalRpcClient rpcClient = null;
+            try {
+                WaltzClientConfig waltzClientConfig = getWaltzClientConfig(cliConfigPath);
+                DummyTxnCallbacks callbacks = new DummyTxnCallbacks();
+                rpcClient = new InternalRpcClient(ClientSSL.createContext(waltzClientConfig.getSSLConfig()),
+                    WaltzClientConfig.DEFAULT_MAX_CONCURRENT_TRANSACTIONS, callbacks);
+
+                if (!(Boolean) rpcClient.removePreferredPartition(serverEndpoint, partitionId).get()) {
+                    System.out.println("Failed to remove preferred partition " + partitionId + " from server Endpoint "
+                        + serverEndpoint + ".");
+                }
+            } catch (Exception e) {
+                throw new SubCommandFailedException(String.format("Failed to remove preferred partition %s to the "
+                    + "server Endpoint %s. %n%s ", partitionId, serverEndpoint.toString(), e));
+            } finally {
+                if (rpcClient != null) {
+                    rpcClient.close();
+                }
+            }
+        }
+
+        @Override
+        protected String getUsage() {
+            return buildUsage(NAME, DESCRIPTION, getOptions());
+        }
+    }
+
+    /**
+     * Return an object of {@code WaltzClientConfig} built from configuration file.
+     * @param configFilePath the path to configuration file
+     * @return WaltzClientConfig
+     * @throws IOException
+     */
+    private static WaltzClientConfig getWaltzClientConfig(String configFilePath) throws IOException {
+        Yaml yaml = new Yaml();
+        try (FileInputStream in = new FileInputStream(configFilePath)) {
+            Map<Object, Object> props = yaml.load(in);
+            props.put(WaltzClientConfig.AUTO_MOUNT, false);
+            return new WaltzClientConfig(props);
+        }
+    }
+
+    /**
+     * A transaction callback to help construct {@link WaltzClient}. It is dummy because
+     * it is not suppose to receive any callbacks.
+     */
+    private static final class DummyTxnCallbacks implements WaltzClientCallbacks {
+
+        @Override
+        public long getClientHighWaterMark(int partitionId) {
+            return -1L;
+        }
+
+        @Override
+        public void applyTransaction(Transaction transaction) {
+        }
+
+        @Override
+        public void uncaughtException(int partitionId, long transactionId, Throwable exception) {
         }
     }
 


### PR DESCRIPTION
This PR implements a cli to add/ remove preferred partitions.

If a partition is assigned as a preferred partition to a WaltzServer, then that WaltzServer should still have the same partition assigned to it when the rebalance happens later. Unless, that same partition is assigned as preferred partition to some other WaltzServer as well. In that case, most probably the WaltzServer whose server_id is smaller compared to the other server_ids (who also have the same partition assigned as preferred partition) will get the partition assigned to it.


For Eg: Given 2 partitions: P0, P1
**Step 1:** Server1 is added to the cluster
Server 1 ===>
Partitions: [P0, P1]        Preferred Partitions: [*]  (Note: * means null. No preferred partitions are assigned.)

**Step 2:** Add P1 as preferred partition to Server1
Server 1 ====>
Partitions: [P0, P1]        Preferred Partitions: [P1]

**Step 3:** Server2 is added to the cluster
Server 1 ====>
Partitions: [P1]        Preferred Partitions: [P1]
Server 2 ====>
Partitions: [P0]        Preferred Partitions: [*]
(Note: Partition P1 will remain assigned to Server 1)

**Step 4:** Add P1 as preferred partition to Server2
Server 1 ====>
Partitions: [P1]        Preferred Partitions: [P1]
Server 2 ====>
Partitions: [P0]        Preferred Partitions: [P1]
(Note: No change in partition assignment)

**Step 5:** Remove P1 as preferred partition from Server1
Server 1 ====>
Partitions: [P0]        Preferred Partitions: [*]
Server 2 ====>
Partitions: [P1]        Preferred Partitions: [P1]
(Note: Partition assignment will be changed)