### PR TITLE
Include server-storage connectivity checks in cluster-cli verify

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/RpcClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/RpcClient.java
@@ -5,7 +5,6 @@ import com.wepay.zktools.clustermgr.Endpoint;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 /**
@@ -19,7 +18,7 @@ public interface RpcClient {
 
     Future<Long> getHighWaterMark(int partitionId);
 
-    CompletableFuture<Map<Endpoint, Map<String, Boolean>>>  checkServerConnections(Set<Endpoint> serverEndpoints);
+    Future<Map<Endpoint, Map<String, Boolean>>> checkServerConnections(Set<Endpoint> serverEndpoints) throws InterruptedException;
 
     Future<List<Integer>> getServerPartitionAssignments(Endpoint serverEndpoint) throws InterruptedException;
 }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandlerCallbacks.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandlerCallbacks.java
@@ -81,7 +81,15 @@ public interface WaltzClientHandlerCallbacks extends MessageHandlerCallbacks {
      */
     void onHighWaterMarkReceived(int partitionId, long highWaterMark);
 
+    /**
+     * Handles the received check connectivity response message.
+     * @param storageConnectivityMap Connectivity status map of all storage nodes within the cluster.
+     */
     void onCheckStorageConnectivityResponseReceived(Map<String, Boolean> storageConnectivityMap);
 
+    /**
+     * Handles the received partition assignment response message.
+     * @param partitions List of all the partitions this server is assigned to.
+     */
     void onServerPartitionsAssignmentResponseReceived(List<Integer> partitions);
 }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzNetworkClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzNetworkClient.java
@@ -5,6 +5,7 @@ import com.wepay.riff.network.MessageProcessingThreadPool;
 import com.wepay.riff.network.NetworkClient;
 import com.wepay.riff.util.Logging;
 import com.wepay.waltz.client.internal.Partition;
+import com.wepay.waltz.common.message.AbstractMessage;
 import com.wepay.waltz.common.message.CheckStorageConnectivityRequest;
 import com.wepay.waltz.common.message.FeedRequest;
 import com.wepay.waltz.common.message.HighWaterMarkRequest;
@@ -27,8 +28,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A {@link NetworkClient} implementation for waltz clients to communicate with Waltz cluster.
@@ -49,9 +48,7 @@ public class WaltzNetworkClient extends NetworkClient {
     private final HashMap<Integer, Partition> partitions;
 
     private boolean channelReady = false;
-    private static final int CHANNEL_NOT_READY_TIMEOUT = 5000;
     private volatile boolean running = true;
-    private AtomicReference<CompletableFuture<Optional<Map<String, Boolean>>>> checkConnectivityRef;
     private Map<Integer, CompletableFuture<Object>> outputFuturesPerMessageType;
 
     /**
@@ -80,16 +77,14 @@ public class WaltzNetworkClient extends NetworkClient {
         this.networkClientCallbacks = networkClientCallbacks;
         this.messageProcessingThreadPool = messageProcessingThreadPool;
         this.partitions = new HashMap<>();
-        this.checkConnectivityRef = new AtomicReference<>();
         this.outputFuturesPerMessageType = new ConcurrentHashMap<>();
     }
 
     /**
      * Shuts down this instance by
-     *  - un-mounting all partitions,
-     *  - setting {@link #running} to {@code false} and
-     *  - completing the {@link #checkConnectivityRef}.future (with empty value) if its not already complete. This
-     *  might be called if the server is down or if there is any network error.
+     *  - Un-mounting all partitions,
+     *  - Setting {@link #running} to {@code false}, and
+     *  - Completing the futures in {@code outputFuturesPerMessageType} with an exception
      */
     @Override
     protected void shutdown() {
@@ -103,17 +98,14 @@ public class WaltzNetworkClient extends NetworkClient {
                     partition.unmounted(this);
                 }
 
-                CompletableFuture<Optional<Map<String, Boolean>>> future = checkConnectivityRef.get();
-                if (future != null) {
-                    if (checkConnectivityRef.compareAndSet(future, null)) {
-                        future.complete(Optional.empty());
-                    }
-                }
-
-                outputFuturesPerMessageType.values().forEach(futureOutput -> futureOutput.completeExceptionally(
-                        new Exception("waltz network client instance shutting down")
-                ));
+                outputFuturesPerMessageType.values().stream()
+                    .filter(future -> !future.isDone())
+                    .forEach(future ->
+                        future.completeExceptionally(new Exception("waltz network client instance shutting down"))
+                    );
             }
+
+            lock.notifyAll();
         }
         networkClientCallbacks.onNetworkClientDisconnected(this);
     }
@@ -212,80 +204,75 @@ public class WaltzNetworkClient extends NetworkClient {
 
     /**
      * Checks server to storage connectivity.
+     * The current thread waits for channel readiness before sending the request to the server. If this client
+     * is shutdown before that, an exceptionally completed CompletableFuture is returned.
      *
-     * Note: There is a possibility that the channel may not be up when this method gets triggered. In that case,
-     * CHECK_STORAGE_CONNECTIVITY_REQUEST is resent once the channel is active.
-     *
-     * @return Completable future with the connectivity status to the storage nodes within the cluster.
+     * @return a CompletableFuture which will complete with connectivity statuses between this server and
+     * all the storage nodes in the cluster, or with an exception, if any.
+     * @throws InterruptedException If thread interrupted while waiting for channel to be ready.
      */
-    public CompletableFuture<Optional<Map<String, Boolean>>> checkServerToStorageConnectivity() {
-        while (true) {
-            CompletableFuture<Optional<Map<String, Boolean>>> future = checkConnectivityRef.get();
-            if (future != null) {
-                return future;
-            } else {
-                future = new CompletableFuture<>();
-                if (checkConnectivityRef.compareAndSet(null, future)) {
-                    sendCheckStorageConnectivityRequest();
-                    return future;
-                }
-            }
-        }
+    @SuppressWarnings("unchecked")
+    public CompletableFuture<Map<String, Boolean>> checkServerToStorageConnectivity() throws InterruptedException {
+        ReqId dummyReqId = new ReqId(clientId, 0, 0, 0);
+        CompletableFuture<Object> responseFuture =
+            sendRequestOnChannelActive(new CheckStorageConnectivityRequest(dummyReqId));
+
+        return responseFuture.thenApply(response -> (Map<String, Boolean>) response);
     }
 
     /**
-     * Requests list of partitions assigned on that server
+     * Requests the list of partitions assigned to this server.
+     * The current thread waits for channel readiness before sending the request to the server. If this client
+     * is shutdown before that, an exceptionally completed CompletableFuture is returned.
      *
-     * @return Completable future that will container the list of partitions assigned on that server
-     * @throws InterruptedException If thread interrupted while waiting for channel to be ready
+     * @return a CompletableFuture which will complete with the list of partitions assigned to this server,
+     * or with an exception, if any.
+     * @throws InterruptedException If thread interrupted while waiting for the channel to be ready
      */
-    public Future<List<Integer>> getServerPartitionAssignments() throws InterruptedException {
+    @SuppressWarnings("unchecked")
+    public CompletableFuture<List<Integer>> getServerPartitionAssignments() throws InterruptedException {
+        ReqId dummyReqId = new ReqId(clientId, 0, 0, 0);
+        CompletableFuture<Object> responseFuture =
+            sendRequestOnChannelActive(new ServerPartitionsAssignmentRequest(dummyReqId));
+
+        return responseFuture.thenApply(response -> (List<Integer>) response);
+    }
+
+    private CompletableFuture<Object> sendRequestOnChannelActive(AbstractMessage requestMessage) throws InterruptedException {
         synchronized (lock) {
-            if (running && !channelReady) {
-                lock.wait(CHANNEL_NOT_READY_TIMEOUT);
+            while (running && !channelReady) {
+                lock.wait();
             }
 
             if (!running) {
-                CompletableFuture<List<Integer>> future = new CompletableFuture<>();
+                CompletableFuture<Object> future = new CompletableFuture<>();
                 future.completeExceptionally(new Exception("Cannot reach server, network client instance shutdown"));
                 return future;
-            } else if (!channelReady) {
-                CompletableFuture<List<Integer>> future = new CompletableFuture<>();
-                future.completeExceptionally(new Exception("Cannot reach server, channel not ready"));
-                return future;
-            }
-
-            CompletableFuture<Object> future = outputFuturesPerMessageType.get(MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST);
-
-            while (true) {
-                if (future != null && !(future.isDone())) {
-                    return future.thenApply(f -> (List) f);
-                } else {
-                    future = new CompletableFuture<>();
-                    CompletableFuture<Object> oldFuture = outputFuturesPerMessageType.put(MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST, future);
-                    if (oldFuture == null || oldFuture.isDone()) {
-                        ReqId dummyReqId = new ReqId(clientId, 0, 0, 0);
-                        boolean sent = sendMessage(new ServerPartitionsAssignmentRequest(dummyReqId));
-
-                        if (!sent) {
-                            future.completeExceptionally(new Exception("Couldn't send message"));
-                        }
-                        return future.thenApply(f -> (List) f);
-                    }
-                }
             }
         }
+
+        return outputFuturesPerMessageType
+                .compute(
+                    (int) requestMessage.type(),
+                    (keyMessageType, valueFuture) -> {
+                        if (valueFuture != null && !(valueFuture.isDone())) {
+                            return valueFuture;
+                        }
+
+                        CompletableFuture<Object> newFuture = new CompletableFuture<>();
+                        boolean sent = sendMessage(requestMessage);
+
+                        if (!sent) {
+                            newFuture.completeExceptionally(new Exception("Couldn't send message"));
+                        }
+                        return newFuture;
+                    });
     }
 
     @Override
     protected MessageHandler getMessageHandler() {
         WaltzClientHandlerCallbacks handlerCallbacks = new WaltzClientHandlerCallbacksImpl();
         return new WaltzClientHandler(handlerCallbacks, messageProcessingThreadPool);
-    }
-
-    private void sendCheckStorageConnectivityRequest() {
-        ReqId dummyReqId = new ReqId(clientId, 0, 0, 0);
-        sendMessage(new CheckStorageConnectivityRequest(dummyReqId));
     }
 
     private Partition getPartition(int partitionId) {
@@ -303,11 +290,6 @@ public class WaltzNetworkClient extends NetworkClient {
                 // Actually starting to mount partitions. Call onMountingPartition
                 for (Partition partition : partitions.values()) {
                     networkClientCallbacks.onMountingPartition(WaltzNetworkClient.this, partition);
-                }
-
-                // re-send the check storage connectivity request if waiting for the response.
-                if (checkConnectivityRef.get() != null) {
-                    sendCheckStorageConnectivityRequest();
                 }
 
                 lock.notifyAll();
@@ -453,31 +435,30 @@ public class WaltzNetworkClient extends NetworkClient {
             }
         }
 
-        /**
-         * Handles the check connectivity response message received.
-         * @param storageConnectivityMap Connectivity status map of all storage nodes within the cluster.
-         */
         @Override
         public void onCheckStorageConnectivityResponseReceived(Map<String, Boolean> storageConnectivityMap) {
-            CompletableFuture<Optional<Map<String, Boolean>>> future = checkConnectivityRef.get();
-            if (future != null) {
-                if (checkConnectivityRef.compareAndSet(future, null)) {
-                    future.complete(Optional.of(storageConnectivityMap));
+            outputFuturesPerMessageType.computeIfPresent(
+                MessageType.CHECK_STORAGE_CONNECTIVITY_REQUEST,
+                (keyMessageType, valueFuture) -> {
+                    if (!valueFuture.isDone()) {
+                        valueFuture.complete(storageConnectivityMap);
+                    }
+                    return CompletableFuture.completedFuture(Optional.empty());
                 }
-            }
+            );
         }
 
         @Override
         public void onServerPartitionsAssignmentResponseReceived(List<Integer> partitions) {
-            CompletableFuture<Object> future = outputFuturesPerMessageType.get(MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST);
-
-            if (future != null && !future.isDone()) {
-                CompletableFuture<Object> oldValue = outputFuturesPerMessageType.put(MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST, CompletableFuture.completedFuture(Optional.empty()));
-
-                if (oldValue != null) {
-                    future.complete(partitions);
+            outputFuturesPerMessageType.computeIfPresent(
+                MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST,
+                (keyMessageType, valueFuture) -> {
+                    if (!valueFuture.isDone()) {
+                        valueFuture.complete(partitions);
+                    }
+                    return CompletableFuture.completedFuture(Optional.empty());
                 }
-            }
+            );
         }
     }
 }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzNetworkClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzNetworkClient.java
@@ -100,11 +100,10 @@ public class WaltzNetworkClient extends NetworkClient {
                     partition.unmounted(this);
                 }
 
-                outputFuturesPerMessageType.values().stream()
+                outputFuturesPerMessageType.values()
+                    .stream()
                     .filter(future -> !future.isDone())
-                    .forEach(future ->
-                        future.completeExceptionally(new Exception("waltz network client instance shutting down"))
-                    );
+                    .forEach(future -> future.completeExceptionally(new NetworkClientClosedException()));
             }
 
             lock.notifyAll();
@@ -284,7 +283,7 @@ public class WaltzNetworkClient extends NetworkClient {
 
             if (!running) {
                 CompletableFuture<Object> future = new CompletableFuture<>();
-                future.completeExceptionally(new Exception("Cannot reach server, network client instance shutdown"));
+                future.completeExceptionally(new NetworkClientClosedException());
                 return future;
             }
         }
@@ -298,9 +297,8 @@ public class WaltzNetworkClient extends NetworkClient {
                         }
 
                         CompletableFuture<Object> newFuture = new CompletableFuture<>();
-                        boolean sent = sendMessage(requestMessage);
 
-                        if (!sent) {
+                        if (!sendMessage(requestMessage)) {
                             newFuture.completeExceptionally(new Exception("Couldn't send message"));
                         }
                         return newFuture;

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
@@ -389,10 +389,10 @@ public final class ClusterCli extends SubcommandCli {
                                 .validationResultsMap
                                 .put(
                                     ValidationResult.ValidationType.SERVER_STORAGE_CONNECTIVITY,
-                                    getStorageConnectivityValidationResult(
+                                    buildStorageConnectivityValidationResult(
                                         partitionIdToReplicas.get(partition.partitionId),
-                                        endpoint,
-                                        storageConnectivityResults
+                                        storageConnectivityResults,
+                                        String.format("Server %s", endpoint)
                                     )
                                 )
                         );
@@ -400,33 +400,33 @@ public final class ClusterCli extends SubcommandCli {
                 });
         }
 
-        private ValidationResult getStorageConnectivityValidationResult(Set<String> replicas,
-                                                                        Endpoint serverEndpoint,
-                                                                        Map<String, Boolean> storageConnectivityResults) {
-            String errMsgPrefix = String.format("Server %s", serverEndpoint);
-
+        private ValidationResult buildStorageConnectivityValidationResult(
+            Set<String> storages,
+            Map<String, Boolean> storageConnectivityResults,
+            String errMsgPrefix
+        ) {
             ValidationResult.Status validationStatus = ValidationResult.Status.SUCCESS;
             String errorMsg = "";
 
             if (Objects.isNull(storageConnectivityResults)) {
                 validationStatus = ValidationResult.Status.FAILURE;
-                errorMsg = String.format("%s, no connectivity statuses response from the server", errMsgPrefix);
+                errorMsg = String.format("%s, no connectivity statuses response", errMsgPrefix);
             } else {
-                for (String replica : replicas) {
-                    if (!storageConnectivityResults.containsKey(replica)) {
+                for (String storage : storages) {
+                    if (!storageConnectivityResults.containsKey(storage)) {
                         validationStatus = ValidationResult.Status.FAILURE;
                         errorMsg = errorMsg.concat(System.lineSeparator()).concat(
                             String.format(
-                                "%s, storage replica %s missing in server response",
-                                errMsgPrefix, replica
+                                "%s, storage replica %s missing in connectivity statuses",
+                                errMsgPrefix, storage
                             )
                         );
-                    } else if (!storageConnectivityResults.get(replica)) {
+                    } else if (!storageConnectivityResults.get(storage)) {
                         validationStatus = ValidationResult.Status.FAILURE;
                         errorMsg = errorMsg.concat(System.lineSeparator()).concat(
                             String.format(
-                                "%s, server-storage connectivity check for storage replica %s failed",
-                                errMsgPrefix, replica
+                                "%s, storage connectivity check for storage replica %s failed",
+                                errMsgPrefix, storage
                             )
                         );
                     }

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/cluster/ClusterCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/cluster/ClusterCliTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ClusterCliTest {
@@ -36,7 +37,7 @@ public class ClusterCliTest {
         System.setOut(originalOut);
     }
 
-    Properties createProperties(String connectString, String znodePath, int sessionTimeout, SslSetup sslSetup) {
+    private Properties createProperties(String connectString, String znodePath, int sessionTimeout, SslSetup sslSetup) {
         Properties properties =  new Properties();
         properties.setProperty(CliConfig.ZOOKEEPER_CONNECT_STRING, connectString);
         properties.setProperty(CliConfig.ZOOKEEPER_SESSION_TIMEOUT, String.valueOf(sessionTimeout));
@@ -113,7 +114,7 @@ public class ClusterCliTest {
         }
     }
 
-
+    @Test
     public void testVerifyCommand() throws Exception {
         int numPartitions = 3;
         int numStorageNodes = 3;
@@ -143,8 +144,10 @@ public class ClusterCliTest {
                     "--cli-config-path", configFilePath
             };
             ClusterCli.testMain(args1);
-            assertTrue(!outContent.toString("UTF-8").contains("Validation PARTITION_ASSIGNMENT_ZK_SERVER_CONSISTENCY failed"));
-
+            assertFalse(outContent.toString("UTF-8")
+                .contains("Validation PARTITION_ASSIGNMENT_ZK_SERVER_CONSISTENCY failed"));
+            assertFalse(outContent.toString("UTF-8")
+                .contains("Validation SERVER_STORAGE_CONNECTIVITY failed"));
 
             // Close the server network connection
             WaltzServerRunner waltzServerRunner = helper.getWaltzServerRunner(helper.getServerPort(),
@@ -155,7 +158,10 @@ public class ClusterCliTest {
                     "--cli-config-path", configFilePath
             };
             ClusterCli.testMain(args2);
-            assertTrue(outContent.toString("UTF-8").contains("Validation PARTITION_ASSIGNMENT_ZK_SERVER_CONSISTENCY failed"));
+            assertTrue(outContent.toString("UTF-8")
+                .contains("Validation PARTITION_ASSIGNMENT_ZK_SERVER_CONSISTENCY failed"));
+            assertTrue(outContent.toString("UTF-8")
+                .contains("Validation SERVER_STORAGE_CONNECTIVITY failed"));
         } finally {
             helper.closeAll();
         }


### PR DESCRIPTION
-- Included server-storage connectivity checks in cluster-CLI verify.
-- In the verify command, only the connectivity statuses that correspond to the replicas of the partitions that a server owns are considered.
-- Updated WaltzNetworkClient to use the same pattern for sending all CLI requests.
-- Suppressed casting warnings in WaltzNetworkClient.
-- Updated unit tests for ClusterCli.