### PR TITLE
Add getNumPartitions() for WaltzClient

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClient.java
@@ -195,7 +195,7 @@ public class WaltzClient {
     }
 
     /**
-     * Gets the total number of all partitions of this client, including active ones and inactive ones.
+     * Gets the total number of partitions in this cluster, including active and inactive ones.
      *
      * @return the total number of partitions.
      */

--- a/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClient.java
@@ -195,6 +195,15 @@ public class WaltzClient {
     }
 
     /**
+     * Gets the total number of all partitions of this client, including active ones and inactive ones.
+     *
+     * @return the total number of partitions.
+     */
+    public int getNumPartitions() {
+        return clusterManager.numPartitions();
+    }
+
+    /**
      * Sets ids of partitions for this client to work with.
      * Partitions not in {@code partitionIds} will become inaccessible from this client.
      * To use this method the client must set the {@code client.autoMount} configuration parameter to {@code false}.


### PR DESCRIPTION
Add getNumPartition() to get total number of partitions of a WaltzClient, so that application clients can use this number to calculate which partition id a transaction goes to when the transaction is submitted, and it's easier for debugging partition-related issues. 