### PR TITLE
Bump up minor version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.waltz
 sourceCompatibility=1.8
-version=0.5.1
+version=0.6.0


### PR DESCRIPTION
Bumping up the version before releasing the artifact.
Compared to the previous version 0.5.0, this version contains several feature additions on cli tools(#83, #86, #87 etc), and should be a minor version bump-up.