### PR TITLE
Fix client partition mounting issue

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalBaseClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalBaseClient.java
@@ -293,7 +293,8 @@ public abstract class InternalBaseClient implements WaltzNetworkClientCallbacks,
     }
 
     /**
-     * Asynchronously removes the server by invoking {@link WaltzNetworkClient#close()} on the corresponding network client.
+     * Asynchronously removes the server by invoking {@link WaltzNetworkClient#unmountAllPartitions()} and
+     * {@link WaltzNetworkClient#close()} in that order on the corresponding network client.
      *
      * @param endpoint the {@code Endpoint} of the server to be removed.
      */
@@ -306,6 +307,7 @@ public abstract class InternalBaseClient implements WaltzNetworkClientCallbacks,
                 logger.info("removing server: endpoint=" + endpoint);
                 WaltzNetworkClient networkClient = networkClients.remove(endpoint);
                 if (networkClient != null) {
+                    networkClient.unmountAllPartitions();
                     networkClient.close();
                 }
             }
@@ -424,6 +426,7 @@ public abstract class InternalBaseClient implements WaltzNetworkClientCallbacks,
     private void doSetEndpoints() {
         try {
             synchronized (activePartitions) {
+                logger.debug("setting endpoints, " + endpoints.keySet());
                 for (Map.Entry<Endpoint, List<PartitionInfo>> entry : endpoints.entrySet()) {
                     Endpoint endpoint = entry.getKey();
 


### PR DESCRIPTION
In the following scenario, it is possible that the client(s) end up not mounting the Partitions because their WaltzNetworkClient references are set to null.

With enough tries, we were able to reproduce the issue when there is only one WaltzServer in the cluster. We did not try to reproduce with other cluster configurations.

1. If the server is restarted, the ClusterManager eventually calls `InternalBaseClient#removeServer` and `InternalBaseClient#setEndpoints` in that order.
2. The InternalBaseClient submits those tasks to a **single-threaded** async executor. Thus, the `removeServer` task is executed before `doSetEndpoints`.
3. In the `removeServer` task, it does `WaltzNetworkClient#close` (The actual closing is done in a different thread), the current thread only waits until the `NetworkClient#state` is moved to `CLOSED`, but not until all its partitions are unmounted.
4. So, it is possible that the `doSetEndpoints` is executed before the partitions are unmounted which results in `doSetEndpoints` not creating the new WaltzNetworkClient for the partitions. [Code](https://github.com/wepay/waltz/blob/master/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalBaseClient.java#L443-L449)

In this fix, we unmount the partitions before calling the close so that the `doSetEndpoints` task will create new network clients as required.
