### PR TITLE
Create new StoreSessions on replica assignment changes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.waltz
 sourceCompatibility=1.8
-version=0.6.0
+version=0.7.0

--- a/waltz-server/src/main/java/com/wepay/waltz/server/WaltzServer.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/WaltzServer.java
@@ -179,6 +179,7 @@ public class WaltzServer {
                         Partition partition = partitions.remove(partitionId);
                         if (partition != null) {
                             partition.closeAsync();
+                            store.onPartitionRemoved(partitionId);
                         }
                     }
                     logger.info("partition assigned: " + getPartitionIds() + " endpoint=" + endpoint);

--- a/waltz-server/src/main/java/com/wepay/waltz/store/Store.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/Store.java
@@ -32,4 +32,6 @@ public interface Store {
     Set<ReplicaId> getReplicaIds();
 
     ConnectionConfig getConnectionConfig();
+
+    void onPartitionRemoved(int partitionId);
 }

--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/ReplicaSessionManager.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/ReplicaSessionManager.java
@@ -112,11 +112,16 @@ public class ReplicaSessionManager {
     }
 
     /**
-     * Update replicaIds based on ReplicaAssignments.
+     * A utility method to return a set of ReplicaIds for a given ReplicaAssignments.
      * @param assignments
+     * @return a set of ReplicaIds.
      */
-    private Set<ReplicaId> createReplicaIds(ReplicaAssignments assignments) {
+    protected static Set<ReplicaId> createReplicaIds(ReplicaAssignments assignments) {
         Set<ReplicaId> replicaIds = new HashSet<>();
+        if (assignments == null) {
+            return replicaIds;
+        }
+
         for (Map.Entry<String, int[]> entry : assignments.replicas.entrySet()) {
             String connectString = entry.getKey();
             for (int partitionId : entry.getValue()) {

--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
@@ -120,7 +120,7 @@ public class StoreSessionManager {
     }
 
     /**
-     * Returns a store session.
+     * Returns a store session. If the {@code currentSession} is unusable, creates a new store session.
      * @return a store session
      * @throws RecoveryFailedException
      * @throws StoreSessionManagerException

--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
@@ -115,6 +115,10 @@ public class StoreSessionManager {
         return healthy;
     }
 
+    public boolean isClosed() {
+        return !running.get();
+    }
+
     /**
      * Returns a store session.
      * @return a store session

--- a/waltz-server/src/main/resources/log4j.xml
+++ b/waltz-server/src/main/resources/log4j.xml
@@ -7,7 +7,7 @@
         <param name="Target" value="System.out" />
         <param name="Encoding" value="UTF-8" />
         <layout class="org.apache.log4j.PatternLayout">
-            <param name="ConversionPattern" value="%d{yyyy-MM-dd HH:mm:ss.SSS} UTC %-5p: %c - %m%n" />
+            <param name="ConversionPattern" value="[%t]%d{yyyy-MM-dd HH:mm:ss.SSS} UTC %-5p: %c - %m%n" />
         </layout>
     </appender>
 

--- a/waltz-server/src/test/java/com/wepay/waltz/store/internal/StoreImplTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/store/internal/StoreImplTest.java
@@ -1,0 +1,134 @@
+package com.wepay.waltz.store.internal;
+
+import com.wepay.waltz.common.metadata.PartitionMetadata;
+import com.wepay.waltz.common.metadata.PartitionMetadataSerializer;
+import com.wepay.waltz.common.metadata.ReplicaId;
+import com.wepay.waltz.common.metadata.ReplicaState;
+import com.wepay.waltz.common.metadata.StoreMetadata;
+import com.wepay.waltz.common.metadata.StoreParams;
+import com.wepay.waltz.storage.WaltzStorage;
+import com.wepay.waltz.test.util.IntegrationTestHelper;
+import com.wepay.waltz.test.util.WaltzStorageRunner;
+import com.wepay.zktools.zookeeper.ZNode;
+import com.wepay.zktools.zookeeper.ZooKeeperClient;
+import com.wepay.zktools.zookeeper.internal.ZooKeeperClientImpl;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+public class StoreImplTest {
+    private static final int NUM_REPLICAS = 3;
+    private static final int CLUSTER_NUM_PARTITIONS = 3;
+
+    @Test
+    public void testReplicaAssignmentChangeEffects() throws Exception {
+        IntegrationTestHelper helper = null;
+        ZooKeeperClient zkClient = null;
+        try {
+            String rootPath = "/storeimpl/test";
+            Properties properties = new Properties();
+            properties.setProperty(IntegrationTestHelper.Config.ZNODE_PATH, rootPath);
+
+            properties.setProperty(IntegrationTestHelper.Config.NUM_PARTITIONS, String.valueOf(CLUSTER_NUM_PARTITIONS));
+            properties.setProperty(IntegrationTestHelper.Config.ZK_SESSION_TIMEOUT, "30000");
+            properties.setProperty(IntegrationTestHelper.Config.NUM_STORAGES, String.valueOf(NUM_REPLICAS));
+
+            helper = new IntegrationTestHelper(properties);
+            helper.startZooKeeperServer();
+
+            List<String> storageConnectStrings = new ArrayList<>();
+            List<Integer> adminPorts = new ArrayList<>();
+            for (int s = 0; s < NUM_REPLICAS; s++) {
+                WaltzStorageRunner storageRunner = helper.getWaltzStorageRunner(s);
+                storageRunner.startAsync();
+                WaltzStorage storage = storageRunner.awaitStart();
+                adminPorts.add(storage.adminPort);
+                storageConnectStrings.add(helper.getStorageConnectString(s));
+            }
+
+            // Wait for partition creation on storage nodes.
+            Thread.sleep(500);
+
+            for (int adminPort : adminPorts) {
+                helper.setWaltzStorageAssignmentWithPort(adminPort, true);
+            }
+
+            helper.startWaltzServer(true);
+
+            // Wait for recovery and replica states updates to ZK.
+            Thread.sleep(500);
+
+            ZNode root = new ZNode(rootPath);
+            zkClient = new ZooKeeperClientImpl(helper.getZkConnectString(), helper.getZkSessionTimeout());
+
+            Map<Integer, Long> partitionSessionIds = new HashMap<>();
+            Map<Integer, List<String>> partitionReplicas = new HashMap<>();
+            populateReplicaStateInfo(zkClient, root, partitionSessionIds, partitionReplicas);
+
+            assertEquals(CLUSTER_NUM_PARTITIONS, partitionSessionIds.size());
+            assertEquals(CLUSTER_NUM_PARTITIONS, partitionReplicas.size());
+            partitionReplicas.forEach((partitionId, replicaConnectStrings) ->
+                assertEquals(new HashSet<>(storageConnectStrings), new HashSet<>(replicaConnectStrings))
+            );
+
+            // Remove all partitions from the first storage node.
+            StoreMetadata storeMetadata = new StoreMetadata(zkClient, new ZNode(root, StoreMetadata.STORE_ZNODE_NAME));
+            for (int partitionId = 0; partitionId < CLUSTER_NUM_PARTITIONS; partitionId++) {
+                storeMetadata.removePartition(partitionId, helper.getStorageConnectString(0));
+            }
+
+            // Wait for recovery and replica states updates to ZK.
+            Thread.sleep(1000);
+
+            Map<Integer, Long> newPartitionSessionIds = new HashMap<>();
+            Map<Integer, List<String>> newPartitionReplicas = new HashMap<>();
+            populateReplicaStateInfo(zkClient, root, newPartitionSessionIds, newPartitionReplicas);
+
+            assertEquals(CLUSTER_NUM_PARTITIONS, partitionSessionIds.size());
+            assertEquals(CLUSTER_NUM_PARTITIONS, partitionReplicas.size());
+            newPartitionReplicas.forEach((partitionId, replicaConnectStrings) -> {
+                assertEquals(NUM_REPLICAS - 1, replicaConnectStrings.size());
+                assertTrue(storageConnectStrings.containsAll(replicaConnectStrings));
+            });
+            newPartitionSessionIds.forEach((partitionId, sessionId) ->
+                assertTrue(sessionId > partitionSessionIds.get(partitionId))
+            );
+        } finally {
+            if (zkClient != null) {
+                zkClient.close();
+            }
+            if (helper != null) {
+                helper.closeAll();
+            }
+        }
+    }
+
+    private void populateReplicaStateInfo(ZooKeeperClient zkClient,
+                                          ZNode root,
+                                          Map<Integer, Long> partitionSessionIds,
+                                          Map<Integer, List<String>> partitionReplicas) throws Exception {
+        ZNode storeRoot = new ZNode(root, StoreMetadata.STORE_ZNODE_NAME);
+        StoreMetadata storeMetadata = new StoreMetadata(zkClient, storeRoot);
+        ZNode partitionRoot = new ZNode(storeRoot, StoreMetadata.PARTITION_ZNODE_NAME);
+
+        StoreParams storeParams = storeMetadata.getStoreParams();
+
+        for (int id = 0; id < storeParams.numPartitions; id++) {
+            ZNode znode = new ZNode(partitionRoot, Integer.toString(id));
+            PartitionMetadata partitionMetadata =
+                zkClient.getData(znode, PartitionMetadataSerializer.INSTANCE).value;
+            Map<ReplicaId, ReplicaState> replicaStates = partitionMetadata.replicaStates;
+            partitionSessionIds.putIfAbsent(id, partitionMetadata.sessionId);
+            partitionReplicas.put(id, replicaStates.keySet().stream().map(replicaId ->
+                replicaId.storageNodeConnectString).collect(Collectors.toList()));
+        }
+    }
+}

--- a/waltz-storage/src/main/resources/log4j.xml
+++ b/waltz-storage/src/main/resources/log4j.xml
@@ -7,7 +7,7 @@
         <param name="Target" value="System.out" />
         <param name="Encoding" value="UTF-8" />
         <layout class="org.apache.log4j.PatternLayout">
-            <param name="ConversionPattern" value="%d{yyyy-MM-dd HH:mm:ss.SSS} UTC %-5p: %c - %m%n" />
+            <param name="ConversionPattern" value="[%t]%d{yyyy-MM-dd HH:mm:ss.SSS} UTC %-5p: %c - %m%n" />
         </layout>
     </appender>
 

--- a/waltz-test/src/main/java/com/wepay/waltz/test/mock/MockStore.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/mock/MockStore.java
@@ -37,4 +37,9 @@ public class MockStore implements Store {
     public ConnectionConfig getConnectionConfig() {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void onPartitionRemoved(int partitionId) {
+        // Do nothing
+    }
 }

--- a/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
@@ -46,6 +46,8 @@ import java.util.concurrent.Future;
 public class IntegrationTestHelper {
 
     private static final int STORAGE_GROUP_ID = 0;
+    private static final int CACHE_SIZE = 5120;
+    private static final int TRANSACTION_DATA_CACHE_SIZE = 20480;
 
     private final String sslConfigPath;
     private final SslSetup sslSetup;
@@ -292,6 +294,8 @@ public class IntegrationTestHelper {
                 Map<Object, Object> config = new HashMap<>(props);
                 config.put(WaltzServerConfig.ZOOKEEPER_CONNECT_STRING, zkConnectString);
                 config.put(WaltzServerConfig.ZOOKEEPER_SESSION_TIMEOUT, zkSessionTimeout);
+                config.put(WaltzServerConfig.FEED_CACHE_SIZE, CACHE_SIZE);
+                config.put(WaltzServerConfig.TRANSACTION_DATA_CACHE_SIZE, TRANSACTION_DATA_CACHE_SIZE);
                 if (jettyPort > 0) {
                     config.put(WaltzServerConfig.SERVER_JETTY_PORT, jettyPort);
                 }

--- a/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
@@ -46,7 +46,7 @@ import java.util.concurrent.Future;
 public class IntegrationTestHelper {
 
     private static final int STORAGE_GROUP_ID = 0;
-    // Use smaller caches in testing.
+    // Use smaller caches in testing because defaults allocate quite a lot of memory.
     private static final int CACHE_SIZE = 5120; // 5MB
     private static final int TRANSACTION_DATA_CACHE_SIZE = 20480; // 20MB
 

--- a/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
@@ -46,8 +46,9 @@ import java.util.concurrent.Future;
 public class IntegrationTestHelper {
 
     private static final int STORAGE_GROUP_ID = 0;
-    private static final int CACHE_SIZE = 5120;
-    private static final int TRANSACTION_DATA_CACHE_SIZE = 20480;
+    // Use smaller caches in testing.
+    private static final int CACHE_SIZE = 5120; // 5MB
+    private static final int TRANSACTION_DATA_CACHE_SIZE = 20480; // 20MB
 
     private final String sslConfigPath;
     private final SslSetup sslSetup;

--- a/waltz-test/src/main/java/com/wepay/waltz/test/util/ZooKeeperServerRunner.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/util/ZooKeeperServerRunner.java
@@ -69,7 +69,7 @@ public class ZooKeeperServerRunner extends Runner<ZooKeeperServer> {
     }
 
     protected void closeServer() {
-        server.shutdown(true);
+        server.shutdown();
         server = null;
     }
 

--- a/waltz-test/src/main/java/com/wepay/waltz/test/util/ZooKeeperServerRunner.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/util/ZooKeeperServerRunner.java
@@ -69,7 +69,7 @@ public class ZooKeeperServerRunner extends Runner<ZooKeeperServer> {
     }
 
     protected void closeServer() {
-        server.shutdown();
+        server.shutdown(true);
         server = null;
     }
 


### PR DESCRIPTION
1. On replica assignment change watcher events, close old store sessions and create new sessions on replica assignment changes.
2. Creating new sessions will trigger recovery which results in updates to replicastates info in the ZooKeeper.
3. Earlier, this was done on the next write. However, if writes are not happening, then multiple replica assignment changes without recovery could make the cluster unrecoverable in the future.
4. Since replica assignment changes are done manually, it is hard to enforce "Wait until recovery after every assignment change".
5. So, this pull request attempts to make it automatic by eagerly opening new sessions. It always compares the new assignment with the existing assignment, and further processing is done only if there are any changes. This is to handle no-op watcher handler invocations that happen when there are connection issues between the client and the ZK server.

Tested on a local cluster.