### PR TITLE
Add ZooKeeper connect timeout for CLIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ project.ext {
     slf4jVersion = '1.7.25'
     mockitoVersion = '1.9.5'
     assertjVersion = '3.8.0'
-    zkToolsVersion = '0.7.0'
+    zkToolsVersion = '0.7.1'
     yamlVersion = '1.20'
     riffVersion = '2.4.3'
     jacksonVersion = '2.9.6'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ project.ext {
     slf4jVersion = '1.7.25'
     mockitoVersion = '1.9.5'
     assertjVersion = '3.8.0'
-    zkToolsVersion = '0.6.0'
+    zkToolsVersion = '0.7.0'
     yamlVersion = '1.20'
     riffVersion = '2.4.3'
     jacksonVersion = '2.9.6'

--- a/config/local-docker/waltz-tools.yml
+++ b/config/local-docker/waltz-tools.yml
@@ -1,3 +1,4 @@
 zookeeper.connectString: localhost:42181
 zookeeper.sessionTimeout: 1000
+zookeeper.connectTimeout: 5000
 cluster.root: /waltz_cluster

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/CliConfig.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/CliConfig.java
@@ -19,6 +19,8 @@ public class CliConfig extends AbstractConfig {
     public static final String ZOOKEEPER_CONNECT_STRING = "zookeeper.connectString";
     public static final String ZOOKEEPER_SESSION_TIMEOUT = "zookeeper.sessionTimeout";
     public static final int DEFAULT_ZOOKEEPER_SESSION_TIMEOUT = 30000;
+    public static final String ZOOKEEPER_CONNECT_TIMEOUT = "zookeeper.connectTimeout";
+    public static final int DEFAULT_ZOOKEEPER_CONNECT_TIMEOUT = 10000;
 
     // Cluster
     public static final String CLUSTER_ROOT = "cluster.root";
@@ -28,6 +30,7 @@ public class CliConfig extends AbstractConfig {
         // ZooKeeper
         parsers.put(ZOOKEEPER_CONNECT_STRING, stringParser);
         parsers.put(ZOOKEEPER_SESSION_TIMEOUT, intParser.withDefault(DEFAULT_ZOOKEEPER_SESSION_TIMEOUT));
+        parsers.put(ZOOKEEPER_CONNECT_TIMEOUT, intParser.withDefault(DEFAULT_ZOOKEEPER_CONNECT_TIMEOUT));
 
         // Cluster
         parsers.put(CLUSTER_ROOT, stringParser);

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
@@ -101,8 +101,9 @@ public final class ClusterCli extends SubcommandCli {
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
                 int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+                int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
-                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
 
                 ClusterManager clusterManager = new ClusterManagerImpl(zkClient, root, partitionAssignmentPolicy);
@@ -201,9 +202,10 @@ public final class ClusterCli extends SubcommandCli {
                 ZNode zkRoot = new ZNode((String) cliConfig.get(CliConfig.CLUSTER_ROOT));
                 ZNode storeRoot = new ZNode(zkRoot, StoreMetadata.STORE_ZNODE_NAME);
                 int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+                int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
                 SslContext sslContext = Utils.getSslContext(cliConfigPath, CliConfig.SSL_CONFIG_PREFIX);
 
-                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
 
                 StoreMetadata storeMetadata = new StoreMetadata(zkClient, storeRoot);
                 ClusterManager clusterManager = new ClusterManagerImpl(zkClient, zkRoot, partitionAssignmentPolicy);

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
@@ -140,8 +140,9 @@ public final class StorageCli extends SubcommandCli {
             try {
                 String zkConnectString = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+                int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
-                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout, zkConnectTimeout);
 
                 StoreMetadata storeMetadata = new StoreMetadata(zkClient, new ZNode(zkRoot + '/' + StoreMetadata.STORE_ZNODE_NAME));
                 ConnectionMetadata md = storeMetadata.getConnectionMetadata();
@@ -166,10 +167,11 @@ public final class StorageCli extends SubcommandCli {
             String zkConnectString = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
             String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
             int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+            int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
             try {
                 SslContext sslContext = Utils.getSslContext(cliConfigPath, CliConfig.SSL_CONFIG_PREFIX);
-                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout, zkConnectTimeout);
                 storageAdminClient = openStorageAdminClient(storageHost, storagePort, sslContext, zkClient, zkRoot);
                 return (String) storageAdminClient.getMetrics().get();
             } finally {
@@ -301,11 +303,12 @@ public final class StorageCli extends SubcommandCli {
             String zkConnectString = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
             String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
             int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+            int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
             try {
                 SslContext sslContext = Utils.getSslContext(cliConfigPath, CliConfig.SSL_CONFIG_PREFIX);
 
-                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout, zkConnectTimeout);
 
                 storageAdminClient = openStorageAdminClient(storageHost, storagePort, sslContext, zkClient, zkRoot);
 
@@ -407,10 +410,11 @@ public final class StorageCli extends SubcommandCli {
             String zkConnectString = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
             String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
             int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+            int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
             try {
                 SslContext sslContext = Utils.getSslContext(cliConfigPath, CliConfig.SSL_CONFIG_PREFIX);
-                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout, zkConnectTimeout);
                 storageAdminClient = openStorageAdminClient(storageHost, storagePort, sslContext, zkClient, zkRoot);
                 storageAdminClient.setPartitionAvailable(partitionId, isAvailable).get();
             } finally {
@@ -522,11 +526,12 @@ public final class StorageCli extends SubcommandCli {
             String zkConnectString = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
             String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
             int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+            int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
             try {
                 SslContext sslContext = Utils.getSslContext(cliConfigPath, CliConfig.SSL_CONFIG_PREFIX);
 
-                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout, zkConnectTimeout);
 
                 storageAdminClient = openStorageAdminClient(storageHost, storagePort, sslContext, zkClient, zkRoot);
 
@@ -689,12 +694,13 @@ public final class StorageCli extends SubcommandCli {
             String zkConnectString = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
             String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
             int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+            int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
             try {
                 SslContext sourceSslContext = Utils.getSslContext(sourceSslConfigPath, WaltzServerConfig.SERVER_SSL_CONFIG_PREFIX);
                 SslContext destinationSslContext = Utils.getSslContext(destinationSslConfigPath, WaltzServerConfig.SERVER_SSL_CONFIG_PREFIX);
 
-                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout, zkConnectTimeout);
                 sourceStorageAdminClient = openStorageAdminClient(sourceStorageHost, sourceStorageAdminPort, sourceSslContext, zkClient, zkRoot);
                 destinationStorageClient = openStorageClient(destinationStorageHost, destinationStoragePort, destinationSslContext, zkClient, zkRoot, true);
                 destinationStorageAdminClient = openStorageAdminClient(destinationStorageHost, destinationStorageAdminPort, destinationSslContext, zkClient, zkRoot);
@@ -766,10 +772,11 @@ public final class StorageCli extends SubcommandCli {
             String zkConnectString = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
             String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
             int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+            int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
             try {
                 SslContext sslContext = Utils.getSslContext(cliConfigPath, CliConfig.SSL_CONFIG_PREFIX);
-                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
 
                 StoreMetadata storeMetadata = new StoreMetadata(zkClient, new ZNode(root, StoreMetadata.STORE_ZNODE_NAME));
@@ -841,10 +848,11 @@ public final class StorageCli extends SubcommandCli {
             String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
             String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
             int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+            int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
             try {
                 SslContext sslContext = Utils.getSslContext(cliConfigPath, CliConfig.SSL_CONFIG_PREFIX);
-                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
                 ZNode storeRoot = new ZNode(root, StoreMetadata.STORE_ZNODE_NAME);
 
@@ -1004,9 +1012,10 @@ public final class StorageCli extends SubcommandCli {
             String zkConnectString = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
             String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
             int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+            int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
             try {
                 SslContext sslContext = Utils.getSslContext(cliConfigPath, CliConfig.SSL_CONFIG_PREFIX);
-                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zkConnectString, zkSessionTimeout, zkConnectTimeout);
 
                 storageClient = openStorageClient(storageHost, storagePort, sslContext, zkClient, zkRoot, isOffline);
                 storageAdminClient = openStorageAdminClient(storageHost, storageAdminPort, sslContext, zkClient, zkRoot);

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
@@ -106,8 +106,9 @@ public final class ZooKeeperCli extends SubcommandCli {
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
                 int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+                int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
-                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
                 ZNode storeRoot = new ZNode(root, StoreMetadata.STORE_ZNODE_NAME);
                 StoreMetadata storeMetadata = new StoreMetadata(zkClient, storeRoot);
@@ -237,8 +238,9 @@ public final class ZooKeeperCli extends SubcommandCli {
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
                 int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+                int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
-                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
                 ZNode storeRoot = new ZNode(root, StoreMetadata.STORE_ZNODE_NAME);
                 StoreMetadata storeMetadata = new StoreMetadata(zkClient, storeRoot);
@@ -306,8 +308,9 @@ public final class ZooKeeperCli extends SubcommandCli {
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
                 int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+                int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
-                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
                 String clusterName = cmd.getOptionValue("name");
                 int numPartitions = Integer.parseInt(cmd.getOptionValue("partitions"));
@@ -430,8 +433,9 @@ public final class ZooKeeperCli extends SubcommandCli {
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
                 int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+                int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
-                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
                 String clusterName = cmd.getOptionValue("name");
                 boolean force = cmd.hasOption("force");
@@ -528,8 +532,9 @@ public final class ZooKeeperCli extends SubcommandCli {
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
                 int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+                int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
-                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
                 String storage = cmd.getOptionValue("storage");
                 int adminPort = Integer.parseInt(cmd.getOptionValue("storage-admin-port"));
@@ -600,8 +605,9 @@ public final class ZooKeeperCli extends SubcommandCli {
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
                 int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+                int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
-                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
                 String storage = cmd.getOptionValue("storage");
 
@@ -672,8 +678,9 @@ public final class ZooKeeperCli extends SubcommandCli {
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
                 int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+                int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
-                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
                 int partitionId = Integer.parseInt(cmd.getOptionValue("partition"));
                 String storage = cmd.getOptionValue("storage");
@@ -745,8 +752,9 @@ public final class ZooKeeperCli extends SubcommandCli {
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
                 int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+                int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
-                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
                 int partition = Integer.parseInt(cmd.getOptionValue("partition"));
                 String storage = cmd.getOptionValue("storage");
@@ -811,8 +819,9 @@ public final class ZooKeeperCli extends SubcommandCli {
                 String zookeeperHostPorts = (String) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_STRING);
                 String zkRoot = (String) cliConfig.get(CliConfig.CLUSTER_ROOT);
                 int zkSessionTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_SESSION_TIMEOUT);
+                int zkConnectTimeout = (int) cliConfig.get(CliConfig.ZOOKEEPER_CONNECT_TIMEOUT);
 
-                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout);
+                zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
                 int groupId = Integer.parseInt(cmd.getOptionValue("group"));
 

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/storage/StorageCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/storage/StorageCliTest.java
@@ -543,7 +543,8 @@ public final class StorageCliTest {
     public void testSyncPartitionAssignments() throws Exception {
         int numStorage = 3;
         int numPartition = 12;
-        int zkTimeout = 30000;
+        int zkSessionTimeout = 30000;
+        int zkConnectTimeout = 10000;
         int storageGroupId = 0;
         long segmentSizeThreshold = 400L;
         String localhost = InetAddress.getLocalHost().getCanonicalHostName();
@@ -566,7 +567,7 @@ public final class StorageCliTest {
             // set up zookeeper server
             zkServerRunner = new ZooKeeperServerRunner(portFinder.getPort());
             String zkConnectionString = zkServerRunner.start();
-            zkClient = new ZooKeeperClientImpl(zkConnectionString, zkTimeout);
+            zkClient = new ZooKeeperClientImpl(zkConnectionString, zkSessionTimeout, zkConnectTimeout);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRoot, "test cluster", numPartition);
             ZooKeeperCli.Create.createStores(zkClient, clusterRoot, numPartition);
             StoreMetadata storeMetadata = new StoreMetadata(zkClient, storeRoot);
@@ -579,7 +580,7 @@ public final class StorageCliTest {
                 storageProperties.setProperty(WaltzStorageConfig.STORAGE_DIRECTORY, Files.createTempDirectory(DIR_NAME).toString());
                 storageProperties.setProperty(WaltzStorageConfig.SEGMENT_SIZE_THRESHOLD, String.valueOf(segmentSizeThreshold));
                 storageProperties.setProperty(WaltzStorageConfig.ZOOKEEPER_CONNECT_STRING, zkConnectionString);
-                storageProperties.setProperty(WaltzStorageConfig.ZOOKEEPER_SESSION_TIMEOUT, String.valueOf(zkTimeout));
+                storageProperties.setProperty(WaltzStorageConfig.ZOOKEEPER_SESSION_TIMEOUT, String.valueOf(zkSessionTimeout));
                 storageProperties.setProperty(WaltzStorageConfig.CLUSTER_ROOT, clusterRoot.path);
                 sslSetup.setConfigParams(storageProperties, WaltzStorageConfig.STORAGE_SSL_CONFIG_PREFIX);
                 WaltzStorageConfig storageConfig = new WaltzStorageConfig(storageProperties);

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/zk/ZooKeeperCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/zk/ZooKeeperCliTest.java
@@ -46,6 +46,7 @@ public final class ZooKeeperCliTest {
     private static final int STORAGE_GROUP_0 = 0;
     private static final int STORAGE_GROUP_1 = 1;
     private static final int ZK_SESSION_TIMEOUT = 30000;
+    private static final int ZK_CONNECT_TIMEOUT = 10000;
 
     private static final String CLUSTER_ROOT = "/test/root";
     private static final String CLUSTER_NAME = "tool test";
@@ -86,7 +87,7 @@ public final class ZooKeeperCliTest {
             };
             ZooKeeperCli.testMain(createCommandArgs);
 
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
 
             ZNode root = new ZNode(CLUSTER_ROOT);
 
@@ -137,7 +138,7 @@ public final class ZooKeeperCliTest {
         try {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, NUM_PARTITIONS, STORAGE_GROUP_MAP, STORAGE_CONNECTION_MAP);
 
@@ -201,7 +202,7 @@ public final class ZooKeeperCliTest {
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode groupNode = new ZNode(storeRoot, StoreMetadata.GROUP_ZNODE_NAME);
             ZNode assignmentNode = new ZNode(storeRoot, StoreMetadata.ASSIGNMENT_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, NUM_PARTITIONS, STORAGE_GROUP_MAP, STORAGE_CONNECTION_MAP);
 
@@ -236,7 +237,7 @@ public final class ZooKeeperCliTest {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode groupNode = new ZNode(storeRoot, StoreMetadata.GROUP_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, NUM_PARTITIONS, STORAGE_GROUP_MAP, STORAGE_CONNECTION_MAP);
 
@@ -274,7 +275,7 @@ public final class ZooKeeperCliTest {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode groupNode = new ZNode(storeRoot, StoreMetadata.GROUP_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, NUM_PARTITIONS, STORAGE_GROUP_MAP, STORAGE_CONNECTION_MAP);
 
@@ -314,7 +315,7 @@ public final class ZooKeeperCliTest {
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode groupNode = new ZNode(storeRoot, StoreMetadata.GROUP_ZNODE_NAME);
             ZNode assignmentNode = new ZNode(storeRoot, StoreMetadata.ASSIGNMENT_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, 0, STORAGE_GROUP_MAP, STORAGE_CONNECTION_MAP);
 
@@ -349,7 +350,7 @@ public final class ZooKeeperCliTest {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode groupNode = new ZNode(storeRoot, StoreMetadata.GROUP_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, NUM_PARTITIONS, STORAGE_GROUP_MAP, STORAGE_CONNECTION_MAP);
 
@@ -381,7 +382,7 @@ public final class ZooKeeperCliTest {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode assignmentNode = new ZNode(storeRoot, StoreMetadata.ASSIGNMENT_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, NUM_PARTITIONS, STORAGE_GROUP_MAP, STORAGE_CONNECTION_MAP);
 
@@ -420,7 +421,7 @@ public final class ZooKeeperCliTest {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode assignmentNode = new ZNode(storeRoot, StoreMetadata.ASSIGNMENT_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, NUM_PARTITIONS, STORAGE_GROUP_MAP, STORAGE_CONNECTION_MAP);
 
@@ -455,7 +456,7 @@ public final class ZooKeeperCliTest {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode assignmentNode = new ZNode(storeRoot, StoreMetadata.ASSIGNMENT_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, NUM_PARTITIONS, STORAGE_GROUP_MAP, STORAGE_CONNECTION_MAP);
 
@@ -484,7 +485,7 @@ public final class ZooKeeperCliTest {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode assignmentNode = new ZNode(storeRoot, StoreMetadata.ASSIGNMENT_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, NUM_PARTITIONS, STORAGE_GROUP_MAP, STORAGE_CONNECTION_MAP);
 
@@ -522,7 +523,7 @@ public final class ZooKeeperCliTest {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode assignmentNode = new ZNode(storeRoot, StoreMetadata.ASSIGNMENT_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, NUM_PARTITIONS, STORAGE_GROUP_MAP, STORAGE_CONNECTION_MAP);
 
@@ -560,7 +561,7 @@ public final class ZooKeeperCliTest {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode assignmentNode = new ZNode(storeRoot, StoreMetadata.ASSIGNMENT_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, NUM_PARTITIONS, STORAGE_GROUP_MAP, STORAGE_CONNECTION_MAP);
 
@@ -602,7 +603,7 @@ public final class ZooKeeperCliTest {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode assignmentNode = new ZNode(storeRoot, StoreMetadata.ASSIGNMENT_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, NUM_PARTITIONS, storageGroupMap, storageConnectionMap);
 
@@ -638,7 +639,7 @@ public final class ZooKeeperCliTest {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode assignmentNode = new ZNode(storeRoot, StoreMetadata.ASSIGNMENT_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, numPartitions);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, numPartitions);
 
@@ -677,7 +678,7 @@ public final class ZooKeeperCliTest {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode assignmentNode = new ZNode(storeRoot, StoreMetadata.ASSIGNMENT_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, numPartitions);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, numPartitions);
 
@@ -728,7 +729,7 @@ public final class ZooKeeperCliTest {
             ZNode clusterRootZNode = new ZNode(CLUSTER_ROOT);
             ZNode storeRoot = new ZNode(clusterRootZNode, StoreMetadata.STORE_ZNODE_NAME);
             ZNode assignmentNode = new ZNode(storeRoot, StoreMetadata.ASSIGNMENT_ZNODE_NAME);
-            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT);
+            ZooKeeperClient zkClient = new ZooKeeperClientImpl(connectString, ZK_SESSION_TIMEOUT, ZK_CONNECT_TIMEOUT);
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, numPartitions);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, numPartitions);
 


### PR DESCRIPTION
There's an issue with CLIs that: when ZooKeeper is not running, attempts to run several Storage/ZooKeeper/Cluster CLI commands will get stuck and never exit because the initiation of ZooKeeperClientImpl will keep retrying in this process.

This PR adds a ZOOKEEPER_CONNECT_TIMEOUT parameter to all such initiation calls. Then, if ZooKeeper is not running, such CLI command will exit and throw errors.