### PR TITLE
VerifyCli: Add verification for recovery complete

### DIFF
--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
@@ -48,11 +48,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.HashMap;
-import java.util.TreeMap;
 import java.util.EnumMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -399,7 +397,7 @@ public final class ClusterCli extends SubcommandCli {
                                                                   ZooKeeperClient zkClient,
                                                                   List<PartitionValidationResults> partitionsValidationResultsList) {
             // A set that contains all replica ids in replica assignments
-            Set<ReplicaId> assignmentReplicaIdSet = new TreeSet<>();
+            Set<ReplicaId> assignmentReplicaIdSet = new HashSet<>();
             for (Map.Entry<String, int[]> entry : replicaAssignments.replicas.entrySet()) {
                 for (int partitionId : entry.getValue()) {
                     assignmentReplicaIdSet.add(new ReplicaId(partitionId, entry.getKey()));
@@ -422,8 +420,7 @@ public final class ClusterCli extends SubcommandCli {
                     error = "Cannot obtain replica states";
                 }
 
-                Map<ReplicaId, ReplicaState> sortedReplicaState = new TreeMap<>(replicaState);
-                for (Map.Entry<ReplicaId, ReplicaState> entry : sortedReplicaState.entrySet()) {
+                for (Map.Entry<ReplicaId, ReplicaState> entry : replicaState.entrySet()) {
                     ReplicaId replicaId = entry.getKey();
                     if (!assignmentReplicaIdSet.contains(replicaId)) {
                         error = error.concat(System.lineSeparator())

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
@@ -407,7 +407,7 @@ public final class ClusterCli extends SubcommandCli {
                 }
 
                 ValidationResult validationResult = new ValidationResult(
-                    ValidationResult.ValidationType.STORAGE_RECOVERY_COMPLETE,
+                    ValidationResult.ValidationType.REPLICA_RECOVERY_STATUS,
                     ("".equals(error)) ? ValidationResult.Status.SUCCESS : ValidationResult.Status.FAILURE,
                     error);
                 PartitionValidationResults partitionValidationResults = partitionsValidationResultsList.get(partitionId);
@@ -416,7 +416,7 @@ public final class ClusterCli extends SubcommandCli {
 
             failMissingValidationResults(
                 partitionsValidationResultsList,
-                ValidationResult.ValidationType.STORAGE_RECOVERY_COMPLETE,
+                ValidationResult.ValidationType.REPLICA_RECOVERY_STATUS,
                 "Cannot obtain replica states"
             );
         }
@@ -874,7 +874,7 @@ public final class ClusterCli extends SubcommandCli {
                 SERVER_STORAGE_CONNECTIVITY,
                 PARTITION_ASSIGNMENT_ZK_STORAGE_CONSISTENCY,
                 PARTITION_QUORUM_STATUS,
-                STORAGE_RECOVERY_COMPLETE
+                REPLICA_RECOVERY_STATUS
             }
 
             enum Status {

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/cluster/ClusterCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/cluster/ClusterCliTest.java
@@ -184,7 +184,7 @@ public class ClusterCliTest {
             assertTrue(outContent.toString("UTF-8")
                 .contains("Validation PARTITION_QUORUM_STATUS failed for partition 2"));
 
-            // Check that STORAGE_RECOVERY_COMPLETE didn't fail
+            // Check that REPLICA_RECOVERY_STATUS verification didn't fail
             assertFalse(outContent.toString("UTF-8").contains("Recovery not completed"));
             assertFalse(outContent.toString("UTF-8").contains("Cannot obtain replica states"));
 
@@ -280,7 +280,7 @@ public class ClusterCliTest {
             assertFalse(outContent.toString("UTF-8")
                 .contains("Validation SERVER_STORAGE_CONNECTIVITY failed for partition " + partitionId));
 
-            // Check that STORAGE_RECOVERY_COMPLETE didn't fail
+            // Check that REPLICA_RECOVERY_STATUS verification didn't fail
             assertFalse(outContent.toString("UTF-8").contains("Recovery not completed"));
             assertFalse(outContent.toString("UTF-8").contains("Cannot obtain replica states"));
 

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/cluster/ClusterCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/cluster/ClusterCliTest.java
@@ -184,9 +184,13 @@ public class ClusterCliTest {
             assertTrue(outContent.toString("UTF-8")
                 .contains("Validation PARTITION_QUORUM_STATUS failed for partition 2"));
 
-            // Check that REPLICA_RECOVERY_STATUS verification didn't fail
-            assertFalse(outContent.toString("UTF-8").contains("Recovery not completed"));
-            assertFalse(outContent.toString("UTF-8").contains("Cannot obtain replica states"));
+            // Check that REPLICA_RECOVERY_STATUS validation is success only for Partition 1
+            assertTrue(outContent.toString("UTF-8")
+                .contains("Validation REPLICA_RECOVERY_STATUS failed for partition 0"));
+            assertFalse(outContent.toString("UTF-8")
+                .contains("Validation REPLICA_RECOVERY_STATUS failed for partition 1"));
+            assertTrue(outContent.toString("UTF-8")
+                .contains("Validation REPLICA_RECOVERY_STATUS failed for partition 2"));
 
             // Close the server network connection
             WaltzServerRunner waltzServerRunner = helper.getWaltzServerRunner(helper.getServerPort(),
@@ -281,8 +285,8 @@ public class ClusterCliTest {
                 .contains("Validation SERVER_STORAGE_CONNECTIVITY failed for partition " + partitionId));
 
             // Check that REPLICA_RECOVERY_STATUS verification didn't fail
-            assertFalse(outContent.toString("UTF-8").contains("Recovery not completed"));
-            assertFalse(outContent.toString("UTF-8").contains("Cannot obtain replica states"));
+            assertFalse(outContent.toString("UTF-8")
+                .contains("Validation REPLICA_RECOVERY_STATUS failed for partition " + partitionId));
 
             // Close the server network connection
             WaltzServerRunner waltzServerRunner = helper.getWaltzServerRunner(helper.getServerPort(),

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/cluster/ClusterCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/cluster/ClusterCliTest.java
@@ -184,6 +184,10 @@ public class ClusterCliTest {
             assertTrue(outContent.toString("UTF-8")
                 .contains("Validation PARTITION_QUORUM_STATUS failed for partition 2"));
 
+            // Check that STORAGE_RECOVERY_COMPLETE didn't fail
+            assertFalse(outContent.toString("UTF-8").contains("Recovery not completed"));
+            assertFalse(outContent.toString("UTF-8").contains("Cannot obtain replica states"));
+
             // Close the server network connection
             WaltzServerRunner waltzServerRunner = helper.getWaltzServerRunner(helper.getServerPort(),
                     helper.getServerJettyPort());
@@ -275,6 +279,10 @@ public class ClusterCliTest {
             // Check that server to storage connectivity didn't fail.
             assertFalse(outContent.toString("UTF-8")
                 .contains("Validation SERVER_STORAGE_CONNECTIVITY failed for partition " + partitionId));
+
+            // Check that STORAGE_RECOVERY_COMPLETE didn't fail
+            assertFalse(outContent.toString("UTF-8").contains("Recovery not completed"));
+            assertFalse(outContent.toString("UTF-8").contains("Cannot obtain replica states"));
 
             // Close the server network connection
             WaltzServerRunner waltzServerRunner = helper.getWaltzServerRunner(helper.getServerPort(),


### PR DESCRIPTION
This PR is to verify if the recover is complete for each partition in VerifyCli.
Added a new ValidationType.REPLICA_RECOVERY_STATUS, and this validation result is set to success if and only if:
1. The set of replicas in replica assignments is the same as the set of replicas in replica states.
2. For each replica, the session id in the replicaStates equals the session id in partitionMetadata, and closingHighWaterMark is UNRESOLVED.

If recovery not complete for some replica, the validation result will be printed like:
```
Validation STORAGE_RECOVERY_COMPLETE failed for partition 0
Validation error is:
Storage waltz-storage:55280 recovery not completed
