### PR TITLE
fix append lock in mock client

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockServerPartition.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockServerPartition.java
@@ -123,6 +123,7 @@ public class MockServerPartition {
                         sendMessage(new FeedData(copy(request.reqId), highWaterMark, request.header));
 
                         commit(request.writeLockRequest, highWaterMark);
+                        commit(request.appendLockRequest, highWaterMark);
                     }
                 }
 


### PR DESCRIPTION
This fixes Append locks support in the mock client. Append locks were ignored before this fix.