### PR TITLE
fix a deadlock in high-water mark access in the mock driver

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockClientPartition.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockClientPartition.java
@@ -80,6 +80,10 @@ final class MockClientPartition {
         }
     }
 
+    long getClientHighWaterMark() {
+        return clientHighWaterMark.get();
+    }
+
     void activate() {
         synchronized (this) {
             if (transactionMonitor != null && transactionMonitor.start()) {

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockStreamClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockStreamClient.java
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 class MockStreamClient implements StreamClient {
 
     private final Map<Integer, MockClientPartition> clientPartitions;
-    private final WaltzClientCallbacks callbacks;
 
     private final int clientId;
     private final String clusterName;
@@ -43,7 +42,6 @@ class MockStreamClient implements StreamClient {
         this.clientId = clientId;
         this.clusterName = clusterName;
         this.clientPartitions = MockClientPartition.createForStreamClient(clientId, maxConcurrentTransactions, partitions, callbacks, rpcClient);
-        this.callbacks = callbacks;
         this.autoMount = autoMount;
         if (autoMount) {
             for (Map.Entry<Integer, MockClientPartition> entry : clientPartitions.entrySet()) {

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockStreamClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockStreamClient.java
@@ -75,7 +75,7 @@ class MockStreamClient implements StreamClient {
 
         partition.ensureActive();
 
-        return new TransactionBuilderImpl(partition.nextReqId(), callbacks.getClientHighWaterMark(partitionId));
+        return new TransactionBuilderImpl(partition.nextReqId(), partition.getClientHighWaterMark());
     }
 
     @Override

--- a/waltz-client/src/test/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBCTest.java
+++ b/waltz-client/src/test/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBCTest.java
@@ -308,12 +308,10 @@ public class AbstractClientCallbacksForJDBCTest {
             }
         };
 
-        WaltzClient client1 = new WaltzClient(callbacks1, config1);
-
         dataSource.makeDbDown();
 
         try {
-            client1.submit(mkTransactionContext(0));
+            new WaltzClient(callbacks1, config1);
             fail();
 
         } catch (RuntimeException ex) {


### PR DESCRIPTION
This is a problem with the mock driver. There is a race condition when a client uses the mock driver and a subclass of `AbstractClientCallbacksForJDBC`. `MockStreamClient.getTransactionBuilder()` calls `callbacks.getClientHighWaterMark(partitionId)`. This can cause a deadlock with `AbstractClientCallbacksForJDBC.applyTransaction(transaction)`. 
The fix is not to use `callbacks.getClientHighWaterMark(partitionId)` but to use the client high-water mark cached in `MockClientPartition` similar to what the non-mock driver does.