### PR TITLE
ClientCli producers and consumers running in parallel

### DIFF
--- a/waltz-test/src/main/python/waltz_ducktape/services/cli/client_cli.py
+++ b/waltz-test/src/main/python/waltz_ducktape/services/cli/client_cli.py
@@ -37,5 +37,36 @@ class ClientCli(Cli):
         ]
         return self.build_cmd(cmd_arr)
 
+    def validate_consumer_producer_cluster_cmd(self, num_active_partitions, txn_per_producer, num_producers, num_consumers, interval, previous_high_watermark):
+        """
+        Return validation cli command to submit and validate client transactions, which
+        includes validating high water mark, transaction data and optimistic lock.
+        Every client will be an independent process.
+
+        java com.wepay.waltz.tools.client.ClientCli \
+            client-processes-setup \
+            --txn-per-producer <number of transactions per producer> \
+            --num-producers <number of total producers>
+            --num-consumers <number of total consumers> \
+            --interval <average interval(millisecond) between transactions> \
+            --cli-config-path <client cli config file path> \
+            --num-active-partitions <number of partitions to interact with> \
+            --previous-high-watermark <array of active partition high watermarks value>
+        """
+        cmd_arr = [
+            "java -cp /usr/local/waltz/waltz-uber.jar ",
+            "-Dlog4j.configuration=file:/etc/waltz-client/waltz-log4j.cfg", self.java_cli_class_name(),
+            "client-processes-setup",
+            "--txn-per-producer", txn_per_producer,
+            "--num-producers", num_producers,
+            "--num-consumers", num_consumers,
+            "--interval", interval,
+            "--cli-config-path", self.cli_config_path,
+            "--num-active-partitions {}".format(num_active_partitions) if num_active_partitions is not None else "",
+            "--previous-high-watermark \"{}\"".format(" ".join(str(watermark) for watermark in previous_high_watermark)) if num_active_partitions is not None else "",
+            "--dlog4j-configuration-path /etc/waltz-client/waltz-log4j.cfg"
+        ]
+        return self.build_cmd(cmd_arr)
+
     def java_cli_class_name(self):
         return "com.wepay.waltz.tools.client.ClientCli"

--- a/waltz-test/src/main/python/waltz_ducktape/services/cli/client_cli.py
+++ b/waltz-test/src/main/python/waltz_ducktape/services/cli/client_cli.py
@@ -37,7 +37,7 @@ class ClientCli(Cli):
         ]
         return self.build_cmd(cmd_arr)
 
-    def validate_consumer_producer_cluster_cmd(self, num_active_partitions, txn_per_producer, num_producers, num_consumers, interval, previous_high_watermark):
+    def validate_consumer_producer_cluster_cmd(self, num_active_partitions, txn_per_producer, num_producers, num_consumers, interval):
         """
         Return validation cli command to submit and validate client transactions, which
         includes validating high water mark, transaction data and optimistic lock.
@@ -51,7 +51,6 @@ class ClientCli(Cli):
             --interval <average interval(millisecond) between transactions> \
             --cli-config-path <client cli config file path> \
             --num-active-partitions <number of partitions to interact with> \
-            --previous-high-watermark <array of active partition high watermarks value>
         """
         cmd_arr = [
             "java -cp /usr/local/waltz/waltz-uber.jar ",
@@ -63,7 +62,6 @@ class ClientCli(Cli):
             "--interval", interval,
             "--cli-config-path", self.cli_config_path,
             "--num-active-partitions {}".format(num_active_partitions) if num_active_partitions is not None else "",
-            "--previous-high-watermark \"{}\"".format(" ".join(str(watermark) for watermark in previous_high_watermark)) if num_active_partitions is not None else "",
             "--dlog4j-configuration-path /etc/waltz-client/waltz-log4j.cfg"
         ]
         return self.build_cmd(cmd_arr)

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/producer_consumer_cluster_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/producer_consumer_cluster_test.py
@@ -1,0 +1,49 @@
+from ducktape.mark.resource import cluster
+from ducktape.mark import parametrize
+from ducktape.cluster.cluster_spec import ClusterSpec
+from waltz_ducktape.tests.produce_consume_validate import ProduceConsumeValidateTest
+from ducktape.utils.util import wait_until
+
+
+class ProducerConsumerClusterTest(ProduceConsumeValidateTest):
+    """
+    A class of torture tests that turns on a bunch of ZK, storage, server,
+    and client nodes. Each client is an independent process which makes it easier
+    for client torture testing.
+    """
+    MIN_CLUSTER_SPEC = ClusterSpec.from_list([
+        {'cpu':1, 'mem':'1GB', 'disk':'25GB', 'additional_disks':{'/dev/sdb':'100GB'}, 'num_nodes':3},
+        {'cpu':1, 'mem':'3GB', 'disk':'15GB', 'num_nodes':2},
+        {'cpu':1, 'mem':'1GB', 'disk':'25GB', 'num_nodes':1}])
+
+    def __init__(self, test_context):
+        super(ProducerConsumerClusterTest, self).__init__(test_context=test_context)
+
+    @cluster(cluster_spec=MIN_CLUSTER_SPEC)
+    @parametrize(num_active_partitions=1, txn_per_client=75, num_producers=3, num_consumers=2, interval=250, timeout=360)
+    @parametrize(num_active_partitions=4, txn_per_client=75, num_producers=2, num_consumers=2, interval=500, timeout=360)
+    def test_produce_consume_no_torture(self, num_active_partitions, txn_per_client, num_producers, num_consumers, interval, timeout):
+        self.run_produce_consume_validate(lambda: self.setup_client_side(num_active_partitions, txn_per_client, num_producers, num_consumers, interval, timeout))
+
+
+
+    def setup_client_side(self, num_active_partitions, txn_per_client, num_producers, num_consumers, interval, timeout):
+        previous_high_watermark = self.get_watermark_for_active_partitions(num_active_partitions)
+        validation_producer_consumer_cluster = self.client_cli.validate_consumer_producer_cluster_cmd(num_active_partitions, txn_per_client, num_producers, num_consumers, interval, previous_high_watermark)
+
+        self.verifiable_client.start(validation_producer_consumer_cluster)
+
+        wait_until(lambda: self.verifiable_client.task_complete() == True, timeout_sec=timeout,
+                   err_msg="verifiable_client failed to complete task in %d seconds." % timeout)
+
+    def get_watermark_for_active_partitions(self, num_active_partitions):
+        watermarks = []
+        admin_port = self.waltz_storage.admin_port
+        port = self.waltz_storage.port
+
+        storage_node_hostname = self.waltz_storage.nodes[0].account.ssh_hostname
+        for partition in range(num_active_partitions):
+            watermark = self.get_storage_max_transaction_id(self.get_host(storage_node_hostname, admin_port), port, partition, False)
+            watermarks.append(max(watermark, -1))
+        return watermarks
+

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/producer_consumer_cluster_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/producer_consumer_cluster_test.py
@@ -23,27 +23,6 @@ class ProducerConsumerClusterTest(ProduceConsumeValidateTest):
     @parametrize(num_active_partitions=1, txn_per_client=75, num_producers=3, num_consumers=2, interval=250, timeout=360)
     @parametrize(num_active_partitions=4, txn_per_client=75, num_producers=2, num_consumers=2, interval=500, timeout=360)
     def test_produce_consume_no_torture(self, num_active_partitions, txn_per_client, num_producers, num_consumers, interval, timeout):
-        self.run_produce_consume_validate(lambda: self.setup_client_side(num_active_partitions, txn_per_client, num_producers, num_consumers, interval, timeout))
-
-
-
-    def setup_client_side(self, num_active_partitions, txn_per_client, num_producers, num_consumers, interval, timeout):
-        previous_high_watermark = self.get_watermark_for_active_partitions(num_active_partitions)
-        validation_producer_consumer_cluster = self.client_cli.validate_consumer_producer_cluster_cmd(num_active_partitions, txn_per_client, num_producers, num_consumers, interval, previous_high_watermark)
-
-        self.verifiable_client.start(validation_producer_consumer_cluster)
-
-        wait_until(lambda: self.verifiable_client.task_complete() == True, timeout_sec=timeout,
-                   err_msg="verifiable_client failed to complete task in %d seconds." % timeout)
-
-    def get_watermark_for_active_partitions(self, num_active_partitions):
-        watermarks = []
-        admin_port = self.waltz_storage.admin_port
-        port = self.waltz_storage.port
-
-        storage_node_hostname = self.waltz_storage.nodes[0].account.ssh_hostname
-        for partition in range(num_active_partitions):
-            watermark = self.get_storage_max_transaction_id(self.get_host(storage_node_hostname, admin_port), port, partition, False)
-            watermarks.append(max(watermark, -1))
-        return watermarks
+        validation_cmd = self.client_cli.validate_consumer_producer_cluster_cmd(num_active_partitions, txn_per_client, num_producers, num_consumers, interval)
+        self.run_produce_consume_validate(lambda: self.simple_validation_func(validation_cmd, timeout));
 


### PR DESCRIPTION
Added
- option in WaltzCli to run producers and consumers as individual processes in parallel.
- ducktape test to check functionality of this setup

Aside from using ducktape it is also possible to check functionality of individual parts by setting up a waltz cluster and fire individual commands on a client side

- set up all clients: `java -cp /usr/local/waltz/waltz-uber.jar  -Dlog4j.configuration=file:/etc/waltz-client/waltz-log4j.cfg com.wepay.waltz.tools.client.ClientCli client-processes-setup --txn-per-producer 75 --num-producers 2 --num-consumers 2 --interval 500 --cli-config-path /etc/waltz/waltz_client.yaml --num-active-partitions 4 --previous-high-watermark "-1 -1 -1 -1" --dlog4j-configuration-path /etc/waltz-client/waltz-log4j.cfg`
- create one producer that is part of 2 producers, 2 consumers set up: `java -cp /usr/local/waltz/waltz-uber.jar  -Dlog4j.configuration=file:/etc/waltz-client/waltz-log4j.cfg com.wepay.waltz.tools.client.ClientCli create-producer --txn-per-client 75 --num-clients 2 --cli-config-path /etc/waltz/waltz_client.yaml --num-active-partitions 4 --previous-high-watermark "-1 -1 -1 -1" --interval 3000`
- create one consumer that is part of 2 producers, 2 consumers set up: `java -cp /usr/local/waltz/waltz-uber.jar  -Dlog4j.configuration=file:/etc/waltz-client/waltz-log4j.cfg com.wepay.waltz.tools.client.ClientCli create-consumer --txn-per-client 75 --num-clients 2 --cli-config-path /etc/waltz/waltz_client.yaml --previous-high-watermark "-1 -1 -1 -1" --num-active-partitions 4`