### PR TITLE
Ducktape/Vagrant script update

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ file = IniFile.load('waltz-test/src/main/python/waltz_ducktape/config.ini')
 cfg = file['Vagrant Google']
 
 Vagrant.configure("2") do |config|
-  # Eanble hostmanager so nodes can talk to eachother by DNS
+  # Enable hostmanager so nodes can talk to eachother by DNS
   config.hostmanager.enabled = true
   config.hostmanager.manage_host = true
   config.hostmanager.include_offline = false
@@ -19,7 +19,6 @@ Vagrant.configure("2") do |config|
       node.vm.provider :google do |google, override|
         # google project & service account
         google.google_project_id = cfg['GoogleProjectId']
-        google.google_client_email = cfg['GoogleClientEmail']
         google.google_json_key_location = cfg['GoogleJsonKeyLocation']
 
         # gce image config
@@ -59,7 +58,6 @@ Vagrant.configure("2") do |config|
       node.vm.provider :google do |google, override|
         # google project & service account
         google.google_project_id = cfg['GoogleProjectId']
-        google.google_client_email = cfg['GoogleClientEmail']
         google.google_json_key_location = cfg['GoogleJsonKeyLocation']
 
         # gce image config
@@ -95,7 +93,6 @@ Vagrant.configure("2") do |config|
       node.vm.provider :google do |google, override|
         # google project & service account
         google.google_project_id = cfg['GoogleProjectId']
-        google.google_client_email = cfg['GoogleClientEmail']
         google.google_json_key_location = cfg['GoogleJsonKeyLocation']
 
         # gce image config

--- a/script/client-provision.sh
+++ b/script/client-provision.sh
@@ -1,3 +1,5 @@
 # prepare keystore and truststore file
-sudo cp /vagrant/keystore.jks /etc/waltz-client
-sudo cp /vagrant/truststore.jks /etc/waltz-client
+sudo mkdir /etc/waltz
+sudo chmod a+w /etc/waltz
+sudo cp /vagrant/"$(hostname)".jks /etc/waltz/keystore.jks
+sudo cp /vagrant/truststore.jks /etc/waltz

--- a/script/server-provision.sh
+++ b/script/server-provision.sh
@@ -1,3 +1,5 @@
 # prepare keystore and truststore file
-sudo cp /vagrant/keystore.jks /etc/waltz-server
-sudo cp /vagrant/truststore.jks /etc/waltz-server
+sudo mkdir /etc/waltz
+sudo chmod a+w /etc/waltz
+sudo cp /vagrant/"$(hostname)".jks /etc/waltz/keystore.jks
+sudo cp /vagrant/truststore.jks /etc/waltz

--- a/script/storage-provision.sh
+++ b/script/storage-provision.sh
@@ -1,6 +1,8 @@
 # prepare keystore and truststore file
-sudo cp /vagrant/keystore.jks /etc/waltz-storage
-sudo cp /vagrant/truststore.jks /etc/waltz-storage
+sudo mkdir /etc/waltz
+sudo chmod a+w /etc/waltz
+sudo cp /vagrant/"$(hostname)".jks /etc/waltz/keystore.jks
+sudo cp /vagrant/truststore.jks /etc/waltz
 
 # mount sdb
 sudo mkdir -p /waltzdata

--- a/waltz-test/src/main/python/README.md
+++ b/waltz-test/src/main/python/README.md
@@ -33,15 +33,19 @@ vagrant plugin install vagrant-hostmanager
 #### Prepare keystore and truststore
 
 Put `keystore.jks` and `truststore.jks` under `waltz/vagrant/sync/server` and `waltz/vagrant/sync/storage`'
+Save keystore files as <Vagrant_hostname>.jks
 ```
 waltz
 └─waltz/vagrant
   └─waltz/vagrant/sync
+    ├─waltz/vagrant/sync/client
+    │ ├─waltz/vagrant/sync/client/<Vagrant_hostname>.jks
+    │ └─waltz/vagrant/sync/client/truststore.jks
     ├─waltz/vagrant/sync/server
-    │ ├─waltz/vagrant/sync/server/keystore.jks
+    │ ├─waltz/vagrant/sync/server/<Vagrant_hostname>.jks
     │ └─waltz/vagrant/sync/server/truststore.jks
     └─waltz/vagrant/sync/storage
-      ├─waltz/vagrant/sync/storage/keystore.jks
+      ├─waltz/vagrant/sync/storage/<Vagrant_hostname>.jks
       └─waltz/vagrant/sync/storage/truststore.jks
 ```
 #### Set configuration file
@@ -74,6 +78,11 @@ WaltzServerBootDiskSizeGb=
 # Waltz client GCE configuration (Please fill in all fields)
 WaltzClientImage=
 WaltzClientBootDiskSizeGb=
+
+#======================================================================
+[Zookeeper]
+#======================================================================
+ZkUrl=
 ```
 
 #### Start Vagrant

--- a/waltz-test/src/main/python/waltz_ducktape/config.ini
+++ b/waltz-test/src/main/python/waltz_ducktape/config.ini
@@ -43,7 +43,7 @@ WaltzClientInstanceZone=us-central1-c
 #======================================================================
 # Configurations in this section are shared by tests
 
-ZkUrl=10.73.0.30:2181
+ZkUrl=
 ZkSessionTimeout=40000
 ClusterRoot=/waltz-cluster-root
 ClusterName=waltz-cluster
@@ -52,7 +52,7 @@ ClusterNumPartitions=4
 #======================================================================
 
 [Waltz Storage]
- 
+
 #======================================================================
 # Configurations in this section are shared by tests
 
@@ -67,7 +67,11 @@ AdminPort=7073
 JettyPort=7072
 LibDir=/usr/local/waltz
 DataDir=/usr/local/waltz/data
-ConfigFileDir=/etc/waltz-storage
+ConfigFileDir=/etc/waltz
+SslKeystoreLoc=/etc/waltz/keystore.jks
+SslKeystorePwd=devops
+SslTruststoreLoc=/etc/waltz/truststore.jks
+SslTruststorePwd=devops
 
 #======================================================================
 
@@ -84,10 +88,10 @@ NumNodes=2
 Port=6060
 JettyPort=6062
 LibDir=/usr/local/waltz
-ConfigFileDir=/etc/waltz-server
-SslKeystoreLoc=/etc/waltz-server/keystore.jks
+ConfigFileDir=/etc/waltz
+SslKeystoreLoc=/etc/waltz/keystore.jks
 SslKeystorePwd=devops
-SslTruststoreLoc=/etc/waltz-server/truststore.jks
+SslTruststoreLoc=/etc/waltz/truststore.jks
 SslTruststorePwd=devops
 
 #======================================================================
@@ -102,11 +106,11 @@ NumCpuCores=1
 MemSize=1GB
 DiskSize=25GB
 NumNodes=1
-SslKeystoreLoc=/etc/waltz-client/keystore.jks
+SslKeystoreLoc=/etc/waltz/keystore.jks
 SslKeystorePwd=devops
-SslTruststoreLoc=/etc/waltz-client/truststore.jks
+SslTruststoreLoc=/etc/waltz/truststore.jks
 SslTruststorePwd=devops
 LibDir=/usr/local/waltz
-ConfigFileDir=/etc/waltz-client
+ConfigFileDir=/etc/waltz
 
 #======================================================================

--- a/waltz-test/src/main/python/waltz_ducktape/services/cli/client_cli.py
+++ b/waltz-test/src/main/python/waltz_ducktape/services/cli/client_cli.py
@@ -13,7 +13,7 @@ class ClientCli(Cli):
         """
         super(ClientCli, self).__init__(cli_config_path)
 
-    def validate_txn_cmd(self, num_active_partitions, txn_per_client, num_clients, interval):
+    def validate_txn_cmd(self, log_file_path, num_active_partitions, txn_per_client, num_clients, interval):
         """
         Return validation cli command to submit and validate transactions, which
         includes validating high water mark, transaction data and optimistic lock.
@@ -27,7 +27,7 @@ class ClientCli(Cli):
             --num-active-partitions <number of partitions to interact with>
         """
         cmd_arr = [
-            "java -Dlog4j.configuration=file:/etc/waltz-client/waltz-log4j.cfg", self.java_cli_class_name(),
+            "java -Dlog4j.configuration=file:{}".format(log_file_path), self.java_cli_class_name(),
             "validate",
             "--txn-per-client", txn_per_client,
             "--num-clients", num_clients,

--- a/waltz-test/src/main/python/waltz_ducktape/services/cli/performance_cli.py
+++ b/waltz-test/src/main/python/waltz_ducktape/services/cli/performance_cli.py
@@ -13,7 +13,8 @@ class PerformanceCli(Cli):
         """
         super(PerformanceCli, self).__init__(cli_config_path)
 
-    def producer_test_cmd(self, txn_size, txn_per_thread, num_thread, interval, lock_pool_size=None, num_active_partitions=None, mount_from_latest=None):
+    def producer_test_cmd(self, log_file_path, txn_size, txn_per_thread, num_thread, interval, lock_pool_size=None,
+                          num_active_partitions=None, mount_from_latest=None):
         """
         Return producer performance test command:
 
@@ -29,7 +30,7 @@ class PerformanceCli(Cli):
             --mount_from_latest Waltz Client would be mounted from the latest HighWaterMark (for a partition) on Waltz
         """
         cmd_arr = [
-            "java -Dlog4j.configuration=file:/etc/waltz-client/waltz-log4j.cfg", self.java_cli_class_name(),
+            "java -Dlog4j.configuration=file:{}".format(log_file_path), self.java_cli_class_name(),
             "test-producers",
             "--txn-size", txn_size,
             "--txn-per-thread", txn_per_thread,
@@ -42,7 +43,7 @@ class PerformanceCli(Cli):
         ]
         return self.build_cmd(cmd_arr)
 
-    def consumer_test_cmd(self, txn_size, num_txn, num_active_partitions=None, mount_from_latest=None):
+    def consumer_test_cmd(self, log_file_path, txn_size, num_txn, num_active_partitions=None, mount_from_latest=None):
         """
         Return consumer performance test command:
 
@@ -55,7 +56,7 @@ class PerformanceCli(Cli):
             --mount_from_latest Waltz Client would be mounted from the latest HighWaterMark (for a partition) on Waltz
         """
         cmd_arr = [
-            "java -Dlog4j.configuration=file:/etc/waltz-client/waltz-log4j.cfg", self.java_cli_class_name(),
+            "java -Dlog4j.configuration=file:{}".format(log_file_path), self.java_cli_class_name(),
             "test-consumers",
             "--txn-size", txn_size,
             "--num-txn", num_txn,

--- a/waltz-test/src/main/python/waltz_ducktape/services/templates/waltz_client.yaml
+++ b/waltz-test/src/main/python/waltz_ducktape/services/templates/waltz_client.yaml
@@ -5,6 +5,6 @@ zookeeper:
 cluster.root: {{ cluster_root }}
 
 client.ssl.keyStore.location: {{ ssl_keystore_loc }}
-client.ssl.keyStore.password: {{ ssl_keystore_pwd}}
+client.ssl.keyStore.password: {{ ssl_keystore_pwd }}
 client.ssl.trustStore.location: {{ ssl_truststore_loc }}
 client.ssl.trustStore.password: {{ ssl_truststore_pwd }}

--- a/waltz-test/src/main/python/waltz_ducktape/services/templates/waltz_server.service
+++ b/waltz-test/src/main/python/waltz_ducktape/services/templates/waltz_server.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=waltz-server
+After=network.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5
+User=waltz
+ExecStart=/bin/java \
+    -Dlog4j.configuration=file:/etc/waltz/waltz-log4j.cfg \
+    -cp /usr/local/waltz/waltz-uber.jar \
+    com.wepay.waltz.server.WaltzServer /etc/waltz/waltz_server.yml
+
+[Install]
+WantedBy=multi-user.target

--- a/waltz-test/src/main/python/waltz_ducktape/services/templates/waltz_server.yaml
+++ b/waltz-test/src/main/python/waltz_ducktape/services/templates/waltz_server.yaml
@@ -3,12 +3,12 @@ server:
     jetty.port: {{ jetty_port }}
     ssl:
         keyStore:
-            location: /etc/waltz-server/keystore.jks
-            password: devops
+            location: {{ ssl_keystore_loc }}
+            password: {{ ssl_keystore_pwd }}
             type: JKS
         trustStore:
-            location: /etc/waltz-server/truststore.jks
-            password: devops
+            location: {{ ssl_truststore_loc }}
+            password: {{ ssl_truststore_pwd }}
             type: JKS
 
 zookeeper:

--- a/waltz-test/src/main/python/waltz_ducktape/services/templates/waltz_storage.service
+++ b/waltz-test/src/main/python/waltz_ducktape/services/templates/waltz_storage.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=waltz-storage
+After=network.target
+Requires=waltzdata.mount
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5
+User=waltz
+ExecStart=/bin/java \
+    -Dlog4j.configuration=file:/etc/waltz/waltz-log4j.cfg \
+    -cp /usr/local/waltz/waltz-uber.jar \
+    com.wepay.waltz.storage.WaltzStorage /etc/waltz/waltz_storage.yml
+
+[Install]
+WantedBy=multi-user.target

--- a/waltz-test/src/main/python/waltz_ducktape/services/templates/waltz_storage.yaml
+++ b/waltz-test/src/main/python/waltz_ducktape/services/templates/waltz_storage.yaml
@@ -6,14 +6,16 @@ storage:
     segment.size.threshold: 268435456
     ssl:
         keyStore:
-            location: /etc/waltz-storage/keystore.jks
-            password: devops
+            location: {{ ssl_keystore_loc }}
+            password: {{ ssl_keystore_pwd }}
             type: JKS
         trustStore:
-            location: /etc/waltz-storage/truststore.jks
-            password: devops
+            location: {{ ssl_truststore_loc }}
+            password: {{ ssl_truststore_pwd }}
             type: JKS
 
-cluster:
-    numPartitions: {{ cluster_num_partitions }}
-    key: {{ cluster_key }}
+cluster.root: {{ cluster_root }}
+
+zookeeper:
+    connectString: {{ zk_connect }}
+    sessionTimeout: 30000

--- a/waltz-test/src/main/python/waltz_ducktape/services/waltz_server.py
+++ b/waltz-test/src/main/python/waltz_ducktape/services/waltz_server.py
@@ -3,12 +3,12 @@ from waltz_ducktape.services.base_waltz_service import BaseWaltzService
 
 class WaltzServerService(BaseWaltzService):
     """
-    WaltzStorageService is the service class for Waltz Storage.
+    WaltzServerService is the service class for Waltz Server.
     """
     def __init__(self, context, cluster_spec, zk, cluster_root, cluster_name, cluster_num_partitions, port, jetty_port,
                  lib_dir, config_file_dir, ssl_configs):
         """
-        Construct a new 'WaltzStorageService' object.
+        Construct a new 'WaltzServerService' object.
 
         :param context: The test context
         :param cluster_spec: The cluster specifics
@@ -49,12 +49,22 @@ class WaltzServerService(BaseWaltzService):
     def provision_cmd(self):
         return ""
 
+    def service_config_file_path(self):
+        return "{}/{}.yml".format(self.config_file_dir, "waltz_server")
+
+    def service_file_path(self):
+        return "/etc/systemd/system/waltz-server.service"
+
     def render_log_file(self):
         return self.render('log4j.properties')
 
     def render_service_config_file(self):
-        return self.render('waltz_server.yaml', cluster_root=self.cluster_root, \
-            zk_connect=self.zk, port=self.port, jetty_port=self.jetty_port)
+        return self.render('waltz_server.yaml', cluster_root=self.cluster_root,
+                           zk_connect=self.zk, port=self.port, jetty_port=self.jetty_port,
+                           ssl_keystore_loc=self.ssl_configs["ssl_keystore_loc"],
+                           ssl_keystore_pwd=self.ssl_configs["ssl_keystore_pwd"],
+                           ssl_truststore_loc=self.ssl_configs["ssl_truststore_loc"],
+                           ssl_truststore_pwd=self.ssl_configs["ssl_truststore_pwd"])
 
     def render_cli_config_file(self):
         return self.render('cli.yaml', cluster_root=self.cluster_root,
@@ -64,3 +74,5 @@ class WaltzServerService(BaseWaltzService):
                            ssl_truststore_loc=self.ssl_configs["ssl_truststore_loc"],
                            ssl_truststore_pwd=self.ssl_configs["ssl_truststore_pwd"])
 
+    def render_service_file(self):
+        return self.render('waltz_server.service')

--- a/waltz-test/src/main/python/waltz_ducktape/tests/performance/benchmark_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/performance/benchmark_test.py
@@ -26,7 +26,8 @@ class BenchmarkTest(ProduceConsumeValidateTest):
     @parametrize(txn_size=512, txn_per_thread=100, num_thread=100, interval=10, lock_pool_size=128, num_active_partitions=1, timeout=360)
     @parametrize(txn_size=512, txn_per_thread=100, num_thread=100, interval=10, lock_pool_size=128, num_active_partitions=2, timeout=360)
     def test_producer_performance(self, txn_size, txn_per_thread, num_thread, interval, lock_pool_size, num_active_partitions, timeout):
-        test_cmd = self.performance_cli.producer_test_cmd(txn_size, txn_per_thread, num_thread, interval, lock_pool_size, num_active_partitions)
+        test_cmd = self.performance_cli.producer_test_cmd(self.log_file_path, txn_size, txn_per_thread, num_thread,
+                                                          interval, lock_pool_size, num_active_partitions)
         test_output = self.run_produce_consume_validate(lambda: self.simple_validation_func(test_cmd, timeout))
         self.print_producer_performance(test_output)
 
@@ -35,7 +36,7 @@ class BenchmarkTest(ProduceConsumeValidateTest):
     @parametrize(txn_size=512, num_txn=100000, num_active_partitions=4, timeout=360)
     @parametrize(txn_size=1024, num_txn=100000, num_active_partitions=1, timeout=360)
     def test_consumer_performance(self, txn_size, num_txn, num_active_partitions, timeout):
-        test_cmd = self.performance_cli.consumer_test_cmd(txn_size, num_txn, num_active_partitions)
+        test_cmd = self.performance_cli.consumer_test_cmd(self.log_file_path, txn_size, num_txn, num_active_partitions)
         test_output = self.run_produce_consume_validate(lambda: self.simple_validation_func(test_cmd, timeout))
         self.print_consumer_performance(test_output)
 

--- a/waltz-test/src/main/python/waltz_ducktape/tests/produce_consume_validate.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/produce_consume_validate.py
@@ -31,14 +31,13 @@ class ProduceConsumeValidateTest(WaltzTest):
         self.num_storage_nodes = num_storage_nodes
         self.num_server_nodes = num_server_nodes
         self.num_client_nodes = num_client_nodes
+        self.waltz_storage = self.get_storage_service(self.num_storage_nodes)
         self.waltz_server = self.get_server_service(cluster_num_partitions, self.num_server_nodes)
         self.verifiable_client = self.get_verifiable_client(self.num_client_nodes)
-        # waltz storage will be initiated in reset_cluster()
-        # because cluster key is generated after created cluster
-        self.waltz_storage = None
 
         # initialize waltz cli instances
         self.admin_node = self.waltz_server.get_admin_node()
+        self.log_file_path = self.verifiable_client.log_file_path()
         self.cli_config_path = self.waltz_server.cli_config_file_path()
         self.client_config_path = self.verifiable_client.config_file_path()
         self.zk_cli = ZkCli(self.admin_node, self.cli_config_path)
@@ -114,9 +113,6 @@ class ProduceConsumeValidateTest(WaltzTest):
 
         self.logger.info("Creating Waltz cluster: {}".format(cluster_name))
         self.zk_cli.create_cluster(cluster_name, cluster_num_partitions)
-
-        cluster_key = self.get_cluster_key()
-        self.waltz_storage = self.get_storage_service(cluster_key, cluster_num_partitions, self.num_storage_nodes)
 
     def stop_waltz_client(self):
         self.verifiable_client.stop()

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption.py
@@ -7,31 +7,31 @@ class ConnectionInterruption(Thread):
     A scheduler to drop incoming traffic to a port periodically.
     """
 
-    def __init__(self, service, interruption_length, no_of_interruptions, service_node_index):
+    def __init__(self, service, interruption_length, num_of_interruptions, service_node_index):
         """
             Construct a new 'ConnectionInterruption' object.
 
             :param service: The service having incoming traffic to a port blocked
             :param interruption_length: The interval(milliseconds) between two interruptions and the length of each interruption
-            :param no_of_interruptions: Total number of network connection interruptions
+            :param num_of_interruptions: Total number of network connection interruptions
             :param service_node_index: A service node used for this test
         """
         Thread.__init__(self)
         self.service = service
         self.interruption_length = interruption_length
-        self.interruptions = no_of_interruptions
+        self.num_of_interruptions = num_of_interruptions
         self.service_node_index = service_node_index
 
     def run(self):
         node = self.service.nodes[self.service_node_index]
-        for interruption in range(self.interruptions):
+        for interruption in range(self.num_of_interruptions):
             # let waltz server receive transactions as usual
-            sleep(self.interruption_length/1000)
+            sleep(self.interruption_length)
 
             # disable connection on port
             self.service.logger.info("Closing a port")
             node.account.ssh_capture("sudo iptables -I INPUT -p tcp --destination-port {} -j DROP".format(self.service.port))
-            sleep(self.interruption_length / 1000)
+            sleep(self.interruption_length)
 
             # enable connection on port
             self.service.logger.info("Opening a port")

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption.py
@@ -1,38 +1,70 @@
-from threading import Thread
+from waltz_ducktape.tests.produce_consume_validate import ProduceConsumeValidateTest
+from ducktape.mark.resource import cluster
+from ducktape.mark import parametrize
+from ducktape.cluster.cluster_spec import ClusterSpec
+from ducktape.utils.util import wait_until
 from time import sleep
+from random import randrange
 
 
-class ConnectionInterruption(Thread):
+class ConnectionInterruption(ProduceConsumeValidateTest):
     """
-    A scheduler to drop incoming traffic to a port periodically.
+        Class for tests simulating network issues between server and storage.
     """
 
-    def __init__(self, service, interruption_length, num_of_interruptions, service_node_index):
-        """
-            Construct a new 'ConnectionInterruption' object.
+    MIN_CLUSTER_SPEC = ClusterSpec.from_list([
+        {'cpu': 1, 'mem': '1GB', 'disk': '25GB', 'additional_disks': {'/dev/sdb': '100GB'}, 'num_nodes': 3},
+        {'cpu': 1, 'mem': '3GB', 'disk': '15GB', 'num_nodes': 2},
+        {'cpu': 1, 'mem': '1GB', 'disk': '25GB', 'num_nodes': 1}])
 
-            :param service: The service having incoming traffic to a port blocked
-            :param interruption_length: The interval(milliseconds) between two interruptions and the length of each interruption
-            :param num_of_interruptions: Total number of network connection interruptions
-            :param service_node_index: A service node used for this test
-        """
-        Thread.__init__(self)
-        self.service = service
-        self.interruption_length = interruption_length
-        self.num_of_interruptions = num_of_interruptions
-        self.service_node_index = service_node_index
+    def __init__(self, test_context):
+        super(ConnectionInterruption, self).__init__(test_context=test_context)
 
-    def run(self):
-        node = self.service.nodes[self.service_node_index]
-        for interruption in range(self.num_of_interruptions):
-            # let waltz server receive transactions as usual
-            sleep(self.interruption_length)
+    @cluster(cluster_spec=MIN_CLUSTER_SPEC)
+    @parametrize(num_active_partitions=1, txn_per_client=100, num_clients=2, interval=600, timeout=360,
+                 network_interruption_length=10, num_interruptions=3, duration_between_interruptions=5)
+    @parametrize(num_active_partitions=4, txn_per_client=100, num_clients=2, interval=1000, timeout=300,
+                 network_interruption_length=20, num_interruptions=1, duration_between_interruptions=20)
+    def test_produce_consume_with_network_interruption(self, num_active_partitions, txn_per_client, num_clients, interval, timeout,
+                                                network_interruption_length, num_interruptions, duration_between_interruptions):
+        validation_cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
+        node_idx = self.get_server_node_idx(randrange(min(num_active_partitions, len(self.waltz_server.nodes))))
+        self.run_produce_consume_validate(lambda: self.produce_consume_with_network_interruption(validation_cmd, timeout, network_interruption_length, num_interruptions, duration_between_interruptions, node_idx, num_active_partitions))
+
+    def produce_consume_with_network_interruption(self, validation_cmd, timeout, network_interruption_length, num_interruptions, duration_between_interruptions, node_idx, num_active_partitions):
+        """
+        Set up waltz and interrupt network between a waltz client node and a server node.
+
+        :param validation_cmd: The command that is send to ClientCli
+        :param timeout: Test timeout
+        :param network_interruption_length: Interval in seconds during which client won't be able to connect to server
+        :param num_interruptions: Number of connection interruption cycles
+        :param duration_between_interruptions: Interval in seconds that represents duration between network interruptions
+        :param node_idx: Index of a server node to which client won't be able to connect
+        :param num_active_partitions: Number of active partitions
+        """
+
+        # Start waltz cluster and wait until a storage node registers first transaction
+        self.verifiable_client.start(validation_cmd)
+        admin_port = self.waltz_storage.admin_port
+        port = self.waltz_storage.port
+        wait_until(lambda: self.is_max_transaction_id_updated(self.get_host(self.waltz_storage.nodes[0].account.ssh_hostname, admin_port), port,
+                                                       randrange(num_active_partitions), -1), timeout_sec=timeout)
+
+        node = self.waltz_server.nodes[node_idx]
+        for interruption in range(num_interruptions):
+            sleep(duration_between_interruptions)
 
             # disable connection on port
-            self.service.logger.info("Closing a port")
-            node.account.ssh_capture("sudo iptables -I INPUT -p tcp --destination-port {} -j DROP".format(self.service.port))
-            sleep(self.interruption_length)
+            self.waltz_server.logger.info("Closing a port")
+            node.account.ssh_capture(
+                "sudo iptables -I INPUT -p tcp --destination-port {} -j DROP".format(self.waltz_server.port))
+            sleep(network_interruption_length)
 
             # enable connection on port
-            self.service.logger.info("Opening a port")
-            node.account.ssh_capture("sudo iptables -D INPUT -p tcp --destination-port {} -j DROP".format(self.service.port))
+            self.waltz_server.logger.info("Opening a port")
+            node.account.ssh_capture(
+                "sudo iptables -D INPUT -p tcp --destination-port {} -j DROP".format(self.waltz_server.port))
+
+        wait_until(lambda: self.verifiable_client.task_complete() == True, timeout_sec=timeout,
+                   err_msg="verifiable_client failed to complete task in %d seconds." % timeout)

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption.py
@@ -1,0 +1,38 @@
+from threading import Thread
+from time import sleep
+
+
+class ConnectionInterruption(Thread):
+    """
+    A scheduler to drop incoming traffic to a port periodically.
+    """
+
+    def __init__(self, service, interruption_length, no_of_interruptions, service_node_index):
+        """
+            Construct a new 'ConnectionInterruption' object.
+
+            :param service: The service having incoming traffic to a port blocked
+            :param interruption_length: The interval(milliseconds) between two interruptions and the length of each interruption
+            :param no_of_interruptions: Total number of network connection interruptions
+            :param service_node_index: A service node used for this test
+        """
+        Thread.__init__(self)
+        self.service = service
+        self.interruption_length = interruption_length
+        self.interruptions = no_of_interruptions
+        self.service_node_index = service_node_index
+
+    def run(self):
+        node = self.service.nodes[self.service_node_index]
+        for interruption in range(self.interruptions):
+            # let waltz server receive transactions as usual
+            sleep(self.interruption_length/1000)
+
+            # disable connection on port
+            self.service.logger.info("Closing a port")
+            node.account.ssh_capture("sudo iptables -I INPUT -p tcp --destination-port {} -j DROP".format(self.service.port))
+            sleep(self.interruption_length / 1000)
+
+            # enable connection on port
+            self.service.logger.info("Opening a port")
+            node.account.ssh_capture("sudo iptables -D INPUT -p tcp --destination-port {} -j DROP".format(self.service.port))

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption_test.py
@@ -27,7 +27,8 @@ class ConnectionInterruptionTest(ProduceConsumeValidateTest):
                  interrupt_duration=20, num_interruptions=1, delay_between_interruptions=20)
     def test_client_server_network_interruption(self, num_active_partitions, txn_per_client, num_clients, interval, timeout,
                                                 interrupt_duration, num_interruptions, delay_between_interruptions):
-        validation_cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
+        validation_cmd = self.client_cli.validate_txn_cmd(self.log_file_path, num_active_partitions, txn_per_client,
+                                                          num_clients, interval)
         self.run_produce_consume_validate(lambda: self.client_server_network_interruption(validation_cmd, timeout,
                 interrupt_duration, num_interruptions, delay_between_interruptions, num_active_partitions, interval/1000))
 

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption_test.py
@@ -25,12 +25,11 @@ class ConnectionInterruptionTest(ProduceConsumeValidateTest):
                  interrupt_duration=10, num_interruptions=3, delay_between_interruptions=5)
     @parametrize(num_active_partitions=4, txn_per_client=100, num_clients=2, interval=1000, timeout=300,
                  interrupt_duration=20, num_interruptions=1, delay_between_interruptions=20)
-    def test_produce_consume_client_server_network_interruption(
-            self, num_active_partitions, txn_per_client, num_clients, interval, timeout, interrupt_duration,
-            num_interruptions, delay_between_interruptions):
+    def test_client_server_network_interruption(self, num_active_partitions, txn_per_client, num_clients, interval, timeout,
+                                                interrupt_duration, num_interruptions, delay_between_interruptions):
         validation_cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
-        self.run_produce_consume_validate(lambda: self.produce_consume_client_server_network_interruption(validation_cmd,
-            timeout, interrupt_duration, num_interruptions, delay_between_interruptions, num_active_partitions, interval/1000))
+        self.run_produce_consume_validate(lambda: self.client_server_network_interruption(validation_cmd, timeout,
+                interrupt_duration, num_interruptions, delay_between_interruptions, num_active_partitions, interval/1000))
 
     def drop_traffic_to_port(self, node, port):
         node.account.ssh_capture("sudo iptables -I INPUT -p tcp --destination-port {} -j DROP".format(port))
@@ -38,7 +37,7 @@ class ConnectionInterruptionTest(ProduceConsumeValidateTest):
     def enable_traffic_to_port(self, node, port):
         node.account.ssh_capture("sudo iptables -D INPUT -p tcp --destination-port {} -j DROP".format(port))
 
-    def produce_consume_client_server_network_interruption(self, validation_cmd, timeout, interrupt_duration, num_interruptions,
+    def client_server_network_interruption(self, validation_cmd, timeout, interrupt_duration, num_interruptions,
                                                   delay_between_interruptions, num_active_partitions, processing_duration):
         """
         Set up waltz and interrupt network between a waltz client node and a server node.

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption_test.py
@@ -7,9 +7,9 @@ from time import sleep
 from random import randrange
 
 
-class ConnectionInterruption(ProduceConsumeValidateTest):
+class ConnectionInterruptionTest(ProduceConsumeValidateTest):
     """
-        Class for tests simulating network issues between server and storage.
+        Class for tests simulating network issues corresponding to Waltz Server and Waltz Storage nodes
     """
 
     MIN_CLUSTER_SPEC = ClusterSpec.from_list([
@@ -18,57 +18,63 @@ class ConnectionInterruption(ProduceConsumeValidateTest):
         {'cpu': 1, 'mem': '1GB', 'disk': '25GB', 'num_nodes': 1}])
 
     def __init__(self, test_context):
-        super(ConnectionInterruption, self).__init__(test_context=test_context)
+        super(ConnectionInterruptionTest, self).__init__(test_context=test_context)
 
     @cluster(cluster_spec=MIN_CLUSTER_SPEC)
     @parametrize(num_active_partitions=1, txn_per_client=100, num_clients=2, interval=600, timeout=360,
-                 network_interruption_length=10, num_interruptions=3, duration_between_interruptions=5)
+                 interruption_duration=10, num_interruptions=3, delay_between_interruptions=5)
     @parametrize(num_active_partitions=4, txn_per_client=100, num_clients=2, interval=1000, timeout=300,
-                 network_interruption_length=20, num_interruptions=1, duration_between_interruptions=20)
+                 interruption_duration=20, num_interruptions=1, delay_between_interruptions=20)
     def test_produce_consume_with_network_interruption(self, num_active_partitions, txn_per_client, num_clients, interval, timeout,
-                                                network_interruption_length, num_interruptions, duration_between_interruptions):
+                                                interruption_duration, num_interruptions, delay_between_interruptions):
         validation_cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
-        node_idx = self.get_server_node_idx(randrange(min(num_active_partitions, len(self.waltz_server.nodes))))
-        self.run_produce_consume_validate(lambda: self.produce_consume_with_network_interruption(validation_cmd, timeout, network_interruption_length, num_interruptions, duration_between_interruptions, node_idx, num_active_partitions))
+        self.run_produce_consume_validate(lambda: self.produce_consume_with_network_interruption(validation_cmd, timeout, interruption_duration, num_interruptions, delay_between_interruptions, num_active_partitions))
 
-    def block_connection_to_port(self, node, port):
+    def drop_traffic_to_port(self, node, port):
         node.account.ssh_capture("sudo iptables -I INPUT -p tcp --destination-port {} -j DROP".format(port))
 
-    def enable_connection_to_port(self, node, port):
+    def enable_traffic_to_port(self, node, port):
         node.account.ssh_capture("sudo iptables -D INPUT -p tcp --destination-port {} -j DROP".format(port))
 
-    def produce_consume_with_network_interruption(self, validation_cmd, timeout, network_interruption_length, num_interruptions, duration_between_interruptions, node_idx, num_active_partitions):
+    def produce_consume_with_network_interruption(self, validation_cmd, timeout, interruption_duration, num_interruptions, delay_between_interruptions, num_active_partitions):
         """
         Set up waltz and interrupt network between a waltz client node and a server node.
 
         :param validation_cmd: The command that is send to ClientCli
         :param timeout: Test timeout
-        :param network_interruption_length: Interval in seconds during which client won't be able to connect to server
+        :param interruption_duration: Interval in seconds during which client won't be able to connect to server, must be at least 1
         :param num_interruptions: Number of connection interruption cycles
-        :param duration_between_interruptions: Interval in seconds that represents duration between network interruptions
-        :param node_idx: Index of a server node to which client won't be able to connect
+        :param delay_between_interruptions: Interval in seconds that represents duration between network interruptions
         :param num_active_partitions: Number of active partitions
         """
+
+        partition = randrange(num_active_partitions)
+        node_idx = self.get_server_node_idx(partition)
 
         # Start waltz cluster and wait until a storage node registers first transaction
         self.verifiable_client.start(validation_cmd)
         admin_port = self.waltz_storage.admin_port
         port = self.waltz_storage.port
-        wait_until(lambda: self.is_max_transaction_id_updated(self.get_host(self.waltz_storage.nodes[0].account.ssh_hostname, admin_port), port,
-                                                       randrange(num_active_partitions), -1), timeout_sec=timeout)
+        storage = self.get_host(self.waltz_storage.nodes[0].account.ssh_hostname, admin_port)
+        wait_until(lambda: self.is_max_transaction_id_updated(storage, port, partition, -1), timeout_sec=timeout)
 
         node = self.waltz_server.nodes[node_idx]
         for interruption in range(num_interruptions):
-            sleep(duration_between_interruptions)
-
+            sleep(delay_between_interruptions)
             # disable connection on port
-            self.waltz_server.logger.info("Closing a port")
-            self.block_connection_to_port(node, self.waltz_server.port)
-            sleep(network_interruption_length)
+            self.drop_traffic_to_port(node, self.waltz_server.port)
+
+            # wait for 1 second to propagate any transaction processed in waltz server
+            # and verify that new transactions aren't processed
+            sleep(1)
+            cur_high_watermark = self.get_storage_max_transaction_id(storage, port, partition)
+            sleep(max(interruption_duration - 1, 0))
+            if self.is_max_transaction_id_updated(storage, port, partition, cur_high_watermark):
+                self.enable_traffic_to_port(node, self.waltz_server.port)
+                raise Exception('Network interruption failed')
 
             # enable connection on port
-            self.waltz_server.logger.info("Opening a port")
-            self.enable_connection_to_port(node, self.waltz_server.port)
+            self.enable_traffic_to_port(node, self.waltz_server.port)
 
         wait_until(lambda: self.verifiable_client.task_complete() == True, timeout_sec=timeout,
                    err_msg="verifiable_client failed to complete task in %d seconds." % timeout)

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption_test.py
@@ -21,8 +21,8 @@ class ConnectionInterruptionTest(ProduceConsumeValidateTest):
         super(ConnectionInterruptionTest, self).__init__(test_context=test_context)
 
     @cluster(cluster_spec=MIN_CLUSTER_SPEC)
-    @parametrize(num_active_partitions=1, txn_per_client=100, num_clients=2, interval=600, timeout=360,
-                 interrupt_duration=10, num_interruptions=3, delay_between_interruptions=5)
+    @parametrize(num_active_partitions=1, txn_per_client=150, num_clients=2, interval=600, timeout=360,
+                 interrupt_duration=10, num_interruptions=3, delay_between_interruptions=25)
     @parametrize(num_active_partitions=4, txn_per_client=100, num_clients=2, interval=1000, timeout=300,
                  interrupt_duration=20, num_interruptions=1, delay_between_interruptions=20)
     def test_client_server_network_interruption(self, num_active_partitions, txn_per_client, num_clients, interval, timeout,

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/connection_interruption_test.py
@@ -38,7 +38,7 @@ class ConnectionInterruptionTest(ProduceConsumeValidateTest):
         node.account.ssh_capture("sudo iptables -D INPUT -p tcp --destination-port {} -j DROP".format(port))
 
     def client_server_network_interruption(self, validation_cmd, timeout, interrupt_duration, num_interruptions,
-                                                  delay_between_interruptions, num_active_partitions, processing_duration):
+                                           delay_between_interruptions, num_active_partitions, processing_duration):
         """
         Set up waltz and interrupt network between a waltz client node and a server node.
 

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/recovery_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/recovery_test.py
@@ -59,7 +59,8 @@ class RecoveryTest(ProduceConsumeValidateTest):
         partition = randrange(num_active_partitions)
 
         # Step 1: Submit transactions to all replicas.
-        cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
+        cmd = self.client_cli.validate_txn_cmd(self.log_file_path, num_active_partitions, txn_per_client, num_clients,
+                                               interval)
         self.verifiable_client.start(cmd)
         wait_until(lambda: self.is_max_transaction_id_updated(src_storage, port, partition, -1), timeout_sec=timeout)
 
@@ -103,7 +104,8 @@ class RecoveryTest(ProduceConsumeValidateTest):
         partition = randrange(num_active_partitions)
 
         # Step 1: Produce a number of transactions.
-        cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
+        cmd = self.client_cli.validate_txn_cmd(self.log_file_path, num_active_partitions, txn_per_client, num_clients,
+                                               interval)
         self.verifiable_client.start(cmd)
 
         # Step 2: Mark storage node 0 offline for reads and writes.

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/scalability_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/scalability_test.py
@@ -52,7 +52,8 @@ class ScalabilityTest(ProduceConsumeValidateTest):
         partition = randrange(num_active_partitions)
 
         # Step 1: Produce transactions with current cluster.
-        cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
+        cmd = self.client_cli.validate_txn_cmd(self.log_file_path, num_active_partitions, txn_per_client, num_clients,
+                                               interval)
         self.verifiable_client.start(cmd)
         wait_until(lambda: self.is_max_transaction_id_updated(src_storage, port, partition, -1), timeout_sec=timeout)
 

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/smoke_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/smoke_test.py
@@ -24,14 +24,16 @@ class SmokeTest(ProduceConsumeValidateTest):
     @parametrize(num_active_partitions=1, txn_per_client=500, num_clients=10, interval=120, timeout=240)
     @parametrize(num_active_partitions=4, txn_per_client=500, num_clients=10, interval=120, timeout=240)
     def test_produce_consume_no_torture(self, num_active_partitions, txn_per_client, num_clients, interval, timeout):
-        validation_cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
+        validation_cmd = self.client_cli.validate_txn_cmd(self.log_file_path, num_active_partitions, txn_per_client,
+                                                          num_clients, interval)
         self.run_produce_consume_validate(lambda: self.simple_validation_func(validation_cmd, timeout))
 
     @cluster(cluster_spec=MIN_CLUSTER_SPEC)
     @parametrize(num_active_partitions=1, txn_per_client=500, num_clients=10, interval=120, timeout=480)
     @parametrize(num_active_partitions=4, txn_per_client=500, num_clients=10, interval=120, timeout=480)
     def test_produce_consume_while_bouncing_storage_nodes(self, num_active_partitions, txn_per_client, num_clients, interval, timeout):
-        validation_cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
+        validation_cmd = self.client_cli.validate_txn_cmd(self.log_file_path, num_active_partitions, txn_per_client,
+                                                          num_clients, interval)
         validation_result = self.run_produce_consume_validate(lambda: self.simple_validation_func(validation_cmd, timeout),
                                                               lambda: self._bounce_storage_nodes(3))
         assert "exception" not in validation_result.lower(), "Test failed with exception:\n{}".format(validation_result)
@@ -40,7 +42,8 @@ class SmokeTest(ProduceConsumeValidateTest):
     @parametrize(num_active_partitions=1, txn_per_client=500, num_clients=2, interval=120, timeout=240)
     @parametrize(num_active_partitions=4, txn_per_client=500, num_clients=2, interval=120, timeout=240)
     def test_produce_consume_while_killing_a_server_node(self, num_active_partitions, txn_per_client, num_clients, interval, timeout):
-        validation_cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
+        validation_cmd = self.client_cli.validate_txn_cmd(self.log_file_path, num_active_partitions, txn_per_client,
+                                                          num_clients, interval)
         self.run_produce_consume_validate(lambda: self.simple_validation_func(validation_cmd, timeout),
                                           lambda: self._kill_a_server_node(num_active_partitions))
 

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/smoke_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/smoke_test.py
@@ -45,15 +45,6 @@ class SmokeTest(ProduceConsumeValidateTest):
         self.run_produce_consume_validate(lambda: self.simple_validation_func(validation_cmd, timeout),
                                           lambda: self._kill_a_server_node(num_active_partitions))
 
-    @cluster(cluster_spec=MIN_CLUSTER_SPEC)
-    @parametrize(num_active_partitions=1, txn_per_client=100, num_clients=2, interval=600, timeout=360, interruption_length=10, num_interruptions=3)
-    @parametrize(num_active_partitions=4, txn_per_client=100, num_clients=2, interval=1000, timeout=300, interruption_length=20, num_interruptions=1)
-    def test_produce_consume_client_disconnects(self, num_active_partitions, txn_per_client, num_clients, interval, timeout,
-                                                interruption_length, num_interruptions):
-        validation_cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
-        self.run_produce_consume_validate(lambda: self.simple_validation_func(validation_cmd, timeout),
-                                          lambda: self._disconnect_and_reconnect_client(num_active_partitions, interruption_length, num_interruptions))
-
     def _bounce_storage_nodes(self, interval):
         storage_node_bounce_scheduler = NodeBounceScheduler(service=self.waltz_storage, interval=interval,
                                                             stop_condition=lambda: self.verifiable_client.task_complete())
@@ -67,9 +58,3 @@ class SmokeTest(ProduceConsumeValidateTest):
                                                            stop_condition=lambda: self.verifiable_client.task_complete(),
                                                            iterable_cmd_list=iter(cmd_list))
         server_node_bounce_scheduler.start()
-
-    def _disconnect_and_reconnect_client(self, num_active_partitions, interruption_length, num_of_interruptions):
-        node_idx = self.get_server_node_idx(randrange(min(num_active_partitions, len(self.waltz_server.nodes))))
-        connection_interruption = ConnectionInterruption(service = self.waltz_server, interruption_length = interruption_length,
-                                                        num_of_interruptions = num_of_interruptions, service_node_index = node_idx)
-        connection_interruption.start()

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/smoke_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/smoke_test.py
@@ -46,13 +46,13 @@ class SmokeTest(ProduceConsumeValidateTest):
                                           lambda: self._kill_a_server_node(num_active_partitions))
 
     @cluster(cluster_spec=MIN_CLUSTER_SPEC)
-    @parametrize(num_active_partitions=1, txn_per_client=80, num_clients=2, interval=600, timeout=300, interruption_length=5000, no_interruptions=4)
-    @parametrize(num_active_partitions=4, txn_per_client=100, num_clients=2, interval=1000, timeout=300, interruption_length=20000, no_interruptions=1)
+    @parametrize(num_active_partitions=1, txn_per_client=100, num_clients=2, interval=600, timeout=360, interruption_length=10, num_interruptions=3)
+    @parametrize(num_active_partitions=4, txn_per_client=100, num_clients=2, interval=1000, timeout=300, interruption_length=20, num_interruptions=1)
     def test_produce_consume_client_disconnects(self, num_active_partitions, txn_per_client, num_clients, interval, timeout,
-                                                interruption_length, no_interruptions):
+                                                interruption_length, num_interruptions):
         validation_cmd = self.client_cli.validate_txn_cmd(num_active_partitions, txn_per_client, num_clients, interval)
         self.run_produce_consume_validate(lambda: self.simple_validation_func(validation_cmd, timeout),
-                                          lambda: self._disconnect_and_reconnect_client(num_active_partitions, interruption_length, no_interruptions))
+                                          lambda: self._disconnect_and_reconnect_client(num_active_partitions, interruption_length, num_interruptions))
 
     def _bounce_storage_nodes(self, interval):
         storage_node_bounce_scheduler = NodeBounceScheduler(service=self.waltz_storage, interval=interval,
@@ -68,9 +68,8 @@ class SmokeTest(ProduceConsumeValidateTest):
                                                            iterable_cmd_list=iter(cmd_list))
         server_node_bounce_scheduler.start()
 
-    def _disconnect_and_reconnect_client(self, num_active_partitions, interruption_length, no_of_interruptions):
+    def _disconnect_and_reconnect_client(self, num_active_partitions, interruption_length, num_of_interruptions):
         node_idx = self.get_server_node_idx(randrange(min(num_active_partitions, len(self.waltz_server.nodes))))
-        connection_interruption = ConnectionInterruption(service = self.waltz_server,
-                                                        interruption_length = interruption_length,
-                                                        no_of_interruptions = no_of_interruptions, service_node_index = node_idx)
+        connection_interruption = ConnectionInterruption(service = self.waltz_server, interruption_length = interruption_length,
+                                                        num_of_interruptions = num_of_interruptions, service_node_index = node_idx)
         connection_interruption.start()

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/smoke_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/smoke_test.py
@@ -4,7 +4,6 @@ from ducktape.mark import parametrize
 from ducktape.cluster.cluster_spec import ClusterSpec
 from waltz_ducktape.tests.produce_consume_validate import ProduceConsumeValidateTest
 from waltz_ducktape.tests.validation.node_bounce_scheduler import NodeBounceScheduler
-from waltz_ducktape.tests.validation.connection_interruption import ConnectionInterruption
 
 
 class SmokeTest(ProduceConsumeValidateTest):

--- a/waltz-test/src/main/python/waltz_ducktape/tests/waltz_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/waltz_test.py
@@ -27,12 +27,11 @@ class WaltzTest(Test):
         self.server_cfg = config['Waltz Server']
         self.client_cfg = config['Waltz Client']
 
-    def get_storage_service(self, cluster_key, cluster_num_partitions=None, num_nodes=None):
+    def get_storage_service(self, num_nodes=None):
         """
         Return a Waltz Storage service that uses config.ini for configuration.
         Optional arguments can be pass to override default settings.
         """
-        cluster_num_partitions = cluster_num_partitions or int(self.zk_cfg['ClusterNumPartitions'])
         num_nodes = num_nodes or int(self.storage_cfg['NumNodes'])
         cpu = int(self.storage_cfg['NumCpuCores'])
         mem = self.storage_cfg['MemSize']
@@ -47,9 +46,13 @@ class WaltzTest(Test):
         lib_dir = self.storage_cfg['LibDir']
         data_dir = self.storage_cfg['DataDir']
         config_file_dir = self.storage_cfg['ConfigFileDir']
+        ssl_configs = {"ssl_keystore_loc": self.storage_cfg['SslKeystoreLoc'],
+                       "ssl_keystore_pwd": self.storage_cfg['SslKeystorePwd'],
+                       "ssl_truststore_loc": self.storage_cfg['SslTruststoreLoc'],
+                       "ssl_truststore_pwd": self.storage_cfg['SslTruststorePwd']}
 
-        return WaltzStorageService(self.test_context, cluster_spec, zk, cluster_root, cluster_num_partitions, \
-                                   cluster_key, port, admin_port, jetty_port, lib_dir, data_dir, config_file_dir)
+        return WaltzStorageService(self.test_context, cluster_spec, zk, cluster_root, port, admin_port, jetty_port,
+                                   lib_dir, data_dir, config_file_dir, ssl_configs)
 
     def get_server_service(self, cluster_num_partitions=None, num_nodes=None):
         """
@@ -74,8 +77,8 @@ class WaltzTest(Test):
                        "ssl_truststore_loc": self.server_cfg['SslTruststoreLoc'],
                        "ssl_truststore_pwd": self.server_cfg['SslTruststorePwd']}
 
-        return WaltzServerService(self.test_context, cluster_spec, zk, cluster_root, cluster_name, cluster_num_partitions, \
-                                  port, jetty_port, lib_dir, config_file_dir, ssl_configs)
+        return WaltzServerService(self.test_context, cluster_spec, zk, cluster_root, cluster_name,
+                                  cluster_num_partitions, port, jetty_port, lib_dir, config_file_dir, ssl_configs)
 
     def get_verifiable_client(self, num_nodes=None):
         """


### PR DESCRIPTION
The current PR changes handle:
 - Copying respective keystore and trustore files to the respective VMs
 - Create waltz-storage.service and waltz-server.service files
 - Create a common /etc/waltz directory in all VMs to store service specific yml file (for eg: waltz_storage.yml, waltz_server.yml, waltz_client.yml)
 - Any VM can be picked for any service and it will not fail with config missing error any more. (Note: Except Storage service VMs will always have additional disk) 
 - Cleaned up code to be in sync with the current Waltz implementation.

