### PR TITLE
Waltz Integration Test: Scale up server nodes

### DIFF
--- a/waltz-test/src/main/python/waltz_ducktape/services/cli/server_cli.py
+++ b/waltz-test/src/main/python/waltz_ducktape/services/cli/server_cli.py
@@ -5,13 +5,13 @@ class ServerCli(Cli):
     """
     ServerCli is an utility class to interact with com.wepay.waltz.tools.server.ServerCli.
     """
-    def __init__(self, node):
+    def __init__(self, node, cli_config_path):
         """
         Construct a new 'ServerCli' object.
 
         :param node: The node to run cli command
         """
-        super(ServerCli, self).__init__(node, None)
+        super(ServerCli, self).__init__(cli_config_path)
         self.node = node
 
     def list_partition(self, server):

--- a/waltz-test/src/main/python/waltz_ducktape/tests/produce_consume_validate.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/produce_consume_validate.py
@@ -208,6 +208,9 @@ class ProduceConsumeValidateTest(WaltzTest):
         regex = "server=(\d)*,\s*partition={}".format(partition)
         return int(search(regex, zookeeper_metadata).group(1)) - 1
 
+    def get_number_of_partitions_assigned_to_server(self, server_cli, server):
+        return int(search('There are (\d+) partitions for current server', server_cli.list_partition(server)).group(1))
+
     def get_host(self, hostname, port):
         return "{}:{}".format(hostname, port)
 

--- a/waltz-test/src/main/python/waltz_ducktape/tests/produce_consume_validate.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/produce_consume_validate.py
@@ -222,17 +222,6 @@ class ProduceConsumeValidateTest(WaltzTest):
         """
         self.storage_nodes_to_ignore = nodes_idx
 
-    def shrink_and_reallocate_waltz_server(self, num_of_ignored_nodes):
-        """
-        Deallocate server nodes (which sets free otherwise occupied space in waltz cluster)
-        and reallocate waltz server nodes with updated number of nodes,
-        which is original number of nodes minus num_of_ignored_nodes
-        """
-        cluster_num_partitions = self.waltz_server.cluster_num_partitions
-        self.waltz_server.clean()
-        self.waltz_server.free()
-        self.waltz_server = self.get_server_service(cluster_num_partitions, int(self.server_cfg['NumNodes']) - num_of_ignored_nodes)
-
     def trigger_recovery(self, bounce_node_idx, interval=10):
         """
         Bounce a storage node to trigger recovery procedure. This will force

--- a/waltz-test/src/main/python/waltz_ducktape/tests/produce_consume_validate.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/produce_consume_validate.py
@@ -219,6 +219,17 @@ class ProduceConsumeValidateTest(WaltzTest):
         """
         self.storage_nodes_to_ignore = nodes_idx
 
+    def shrink_and_reallocate_waltz_server(self, num_of_ignored_nodes):
+        """
+        Deallocate server nodes (which sets free otherwise occupied space in waltz cluster)
+        and reallocate waltz server nodes with updated number of nodes,
+        which is original number of nodes minus num_of_ignored_nodes
+        """
+        cluster_num_partitions = self.waltz_server.cluster_num_partitions
+        self.waltz_server.clean()
+        self.waltz_server.free()
+        self.waltz_server = self.get_server_service(cluster_num_partitions, int(self.server_cfg['NumNodes']) - num_of_ignored_nodes)
+
     def trigger_recovery(self, bounce_node_idx, interval=10):
         """
         Bounce a storage node to trigger recovery procedure. This will force

--- a/waltz-test/src/main/python/waltz_ducktape/tests/validation/scalability_test.py
+++ b/waltz-test/src/main/python/waltz_ducktape/tests/validation/scalability_test.py
@@ -4,6 +4,9 @@ from ducktape.mark.resource import cluster
 from ducktape.cluster.cluster_spec import ClusterSpec
 from ducktape.utils.util import wait_until
 from waltz_ducktape.tests.produce_consume_validate import ProduceConsumeValidateTest
+from waltz_ducktape.services.cli.server_cli import ServerCli
+from time import sleep
+import re
 
 
 class ScalabilityTest(ProduceConsumeValidateTest):
@@ -27,6 +30,15 @@ class ScalabilityTest(ProduceConsumeValidateTest):
         self.set_storage_nodes_to_ignore([added_node_idx])
         self.run_produce_consume_validate(lambda: self.scale_up_replica(src_node_idx, added_node_idx, num_active_partitions,
                                                                         txn_per_client, num_clients, interval, timeout))
+
+    @cluster(cluster_spec=MIN_CLUSTER_SPEC)
+    @parametrize(num_active_partitions=4, txn_per_client=500, num_clients=1, interval=100, timeout=240, num_added_nodes=1, delay_before_torture=20)
+    @parametrize(num_active_partitions=1, txn_per_client=200, num_clients=1, interval=200, timeout=240, num_added_nodes=1, delay_before_torture=10)
+    def test_scale_up_server_nodes(self, num_active_partitions, txn_per_client, num_clients, interval, timeout,
+                                   num_added_nodes, delay_before_torture):
+        self.shrink_and_reallocate_waltz_server(num_added_nodes)
+        self.run_produce_consume_validate(lambda: self.scale_up_server(num_active_partitions, txn_per_client, num_clients,
+                                                                       interval, timeout, num_added_nodes, delay_before_torture))
 
     def scale_up_replica(self, src_node_idx, added_node_idx, num_active_partitions, txn_per_client, num_clients, interval, timeout):
         """
@@ -97,3 +109,66 @@ class ScalabilityTest(ProduceConsumeValidateTest):
         assert added_node_max_transaction_id == expected_max_transaction_id, \
             "New transactions failed to reach new replica, expected max transaction ID = {}, actual max transaction ID = {}" \
             .format(expected_max_transaction_id, added_node_max_transaction_id)
+
+    def get_number_of_partitions_assigned_to_server(self, server_cli, server):
+        return int(re.search('There are (\d+) partitions for current server', server_cli.list_partition(server)).group(1))
+
+    def get_random_server_node_instance(self, waltz_server_cluster):
+        server_node = waltz_server_cluster.nodes[randrange(len(waltz_server_cluster.nodes))]
+        server_node_hostname = server_node.account.ssh_hostname
+        return self.get_host(server_node_hostname, waltz_server_cluster.jetty_port)
+
+    def scale_up_server(self, num_active_partitions, txn_per_client, num_clients, interval, timeout, num_added_nodes, delay_before_torture):
+        """
+        A validate function to test scaling up number of servers.
+
+        :param num_active_partitions: Number of active partitions
+        :param txn_per_client: Number of transactions per client
+        :param num_clients: Number of total clients
+        :param interval: Average interval(millisecond) between transactions
+        :param timeout: Test timeout
+        :param num_added_nodes: Number of extra added server nodes
+        :param delay_before_torture: Delay in seconds before new nodes are added after transaction processing starts
+        :returns: Validation result
+        """
+
+        port = self.waltz_storage.port
+        admin_port = self.waltz_storage.admin_port
+        storage_node = self.waltz_storage.nodes[randrange(len(self.waltz_storage.nodes))]
+        storage = self.get_host(storage_node.account.ssh_hostname, admin_port)
+        partition = randrange(num_active_partitions)
+
+        server_cli = ServerCli(self.verifiable_client.nodes[0], self.client_config_path)
+        added_server_nodes = self.get_server_service(int(self.zk_cfg['ClusterNumPartitions']), num_added_nodes)
+
+        original_server = self.get_random_server_node_instance(self.waltz_server)
+        added_server = self.get_random_server_node_instance(added_server_nodes)
+
+        # Step 1: Produce transactions with current cluster.
+        cmd = self.client_cli.validate_txn_cmd(self.log_file_path, num_active_partitions, txn_per_client, num_clients,
+                                               interval)
+        self.verifiable_client.start(cmd)
+        wait_until(lambda: self.is_max_transaction_id_updated(storage, port, partition, -1), timeout_sec=timeout)
+
+        # Step 2: Check partition assignment
+        original_server_num_assigned_partitions_before_test = self.get_number_of_partitions_assigned_to_server(server_cli, original_server)
+        sleep(delay_before_torture)
+
+        # Step 3: Start new server nodes
+        added_server_nodes.start()
+
+        # Step 4: Get partition assignments after adding new server nodes
+        original_server_num_assigned_partitions_after_test = self.get_number_of_partitions_assigned_to_server(server_cli, original_server)
+        added_server_num_assigned_partitions_after_test = self.get_number_of_partitions_assigned_to_server(server_cli, added_server)
+
+        assert added_server_num_assigned_partitions_after_test > 0 and \
+               (original_server_num_assigned_partitions_after_test < original_server_num_assigned_partitions_before_test or
+                original_server_num_assigned_partitions_before_test == 1), \
+            "Number of assigned partitions to server nodes haven't changed after adding new storage node(s) {} = {}, or " \
+            "no partition is assigned to newly added node {}" \
+            .format(original_server_num_assigned_partitions_before_test, original_server_num_assigned_partitions_after_test,
+                    added_server_num_assigned_partitions_after_test)
+
+        # Step 5: Wait until verifiable client ends its task
+        wait_until(lambda: self.verifiable_client.task_complete() == True, timeout_sec=timeout,
+                   err_msg="verifiable_client failed to complete task in {} seconds.".format(timeout))


### PR DESCRIPTION
Waltz Integration Test: Scale up server nodes 
- shrink number of waltz server nodes and reallocate
- check allocation of partitions on waltz server node
- start newly added server nodes
- check the difference in partition assignments on server nodes