### PR TITLE
Pass waltz version from Gradle to waltz server and storage node metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ project.ext {
     riffVersion = '2.4.3'
     jacksonVersion = '2.9.6'
     jettyVersion = '9.4.12.v20180830'
-
     mainClass = 'Main'
+    buildVersionFileName = "waltz-version.properties"
 }
 
 buildscript {
@@ -228,6 +228,28 @@ project(':waltz-server') {
         )
     }
 
+    task createVersionFile {
+        Object receiptFile = file("$buildDir/waltz/$buildVersionFileName")
+        outputs.file receiptFile
+        outputs.upToDateWhen { false }
+        doLast {
+            def data = [
+                    version: version,
+            ]
+
+            receiptFile.parentFile.mkdirs()
+            def content = data.entrySet().collect { "$it.key=$it.value" }.sort().join("\n")
+            receiptFile.setText(content, "ISO-8859-1")
+        }
+    }
+
+    jar {
+        dependsOn createVersionFile
+        from("$buildDir") {
+            include "waltz/$buildVersionFileName"
+        }
+    }
+
     test {
         maxHeapSize = "2G"
         jvmArgs '-Xmx2G'
@@ -264,6 +286,28 @@ project(':waltz-storage') {
             "junit:junit:$junitVersion",
             "org.mockito:mockito-all:$mockitoVersion"
         )
+    }
+
+    task createVersionFile {
+        Object receiptFile = file("$buildDir/waltz/$buildVersionFileName")
+        outputs.file receiptFile
+        outputs.upToDateWhen { false }
+        doLast {
+            def data = [
+                    version: version,
+            ]
+
+            receiptFile.parentFile.mkdirs()
+            def content = data.entrySet().collect { "$it.key=$it.value" }.sort().join("\n")
+            receiptFile.setText(content, "ISO-8859-1")
+        }
+    }
+
+    jar {
+        dependsOn createVersionFile
+        from("$buildDir") {
+            include "waltz/$buildVersionFileName"
+        }
     }
 
     distDocker {

--- a/waltz-common/src/main/java/com/wepay/waltz/common/util/WaltzInfoParser.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/util/WaltzInfoParser.java
@@ -9,7 +9,7 @@ import java.util.Properties;
 /**
  * WaltzInfoParser loads waltz properties from the waltz-version.properties file created a build time.
  */
-public class WaltzInfoParser {
+public final class WaltzInfoParser {
     private static final Logger logger = Logging.getLogger(WaltzInfoParser.class);
     private static final String VERSION;
 
@@ -25,7 +25,8 @@ public class WaltzInfoParser {
         VERSION = props.getProperty("version", DEFAULT_VALUE).trim();
     }
 
-    private WaltzInfoParser() {}
+    private WaltzInfoParser() {
+    }
 
     public static String getVersion() {
         return VERSION;

--- a/waltz-common/src/main/java/com/wepay/waltz/common/util/WaltzInfoParser.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/util/WaltzInfoParser.java
@@ -1,0 +1,33 @@
+package com.wepay.waltz.common.util;
+
+import com.wepay.riff.util.Logging;
+import org.slf4j.Logger;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * WaltzInfoParser loads waltz properties from the waltz-version.properties file created a build time.
+ */
+public class WaltzInfoParser {
+    private static final Logger logger = Logging.getLogger(WaltzInfoParser.class);
+    private static final String VERSION;
+
+    protected static final String DEFAULT_VALUE = "unknown";
+
+    static {
+        Properties props = new Properties();
+        try (InputStream resourceStream = WaltzInfoParser.class.getResourceAsStream("/waltz/waltz-version.properties")) {
+            props.load(resourceStream);
+        } catch (Exception e) {
+            logger.warn("Error while loading waltz-version.properties: {}", e.getMessage());
+        }
+        VERSION = props.getProperty("version", DEFAULT_VALUE).trim();
+    }
+
+    private WaltzInfoParser() {}
+
+    public static String getVersion() {
+        return VERSION;
+    }
+}

--- a/waltz-common/src/main/java/com/wepay/waltz/common/util/WaltzInfoParser.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/util/WaltzInfoParser.java
@@ -7,7 +7,7 @@ import java.io.InputStream;
 import java.util.Properties;
 
 /**
- * WaltzInfoParser loads waltz properties from the waltz-version.properties file created a build time.
+ * WaltzInfoParser loads waltz properties from the waltz-version.properties file created at build time.
  */
 public final class WaltzInfoParser {
     private static final Logger logger = Logging.getLogger(WaltzInfoParser.class);

--- a/waltz-server/src/main/java/com/wepay/waltz/server/WaltzServer.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/WaltzServer.java
@@ -18,6 +18,7 @@ import com.wepay.riff.network.NetworkServer;
 import com.wepay.riff.network.ServerSSL;
 import com.wepay.riff.util.Logging;
 import com.wepay.waltz.common.util.Utils;
+import com.wepay.waltz.common.util.WaltzInfoParser;
 import com.wepay.waltz.exception.ServerException;
 import com.wepay.waltz.server.health.HealthCheck;
 import com.wepay.waltz.server.internal.FeedCache;
@@ -471,6 +472,7 @@ public class WaltzServer {
         REGISTRY.gauge(metricsGroup, "endpoint", (Gauge<String>) () -> endpoint.toString());
         REGISTRY.gauge(metricsGroup, "waltz-server-num-partitions", (Gauge<Integer>) () -> getPartitionIds().size());
         REGISTRY.gauge(metricsGroup, "replica-info", (Gauge<Map<Integer, List<String>>>) () -> getReplicaInfoMap());
+        REGISTRY.gauge(metricsGroup, "waltz_version_id", (Gauge<String>) () -> WaltzInfoParser.getVersion());
     }
 
     private void unregisterMetrics() {

--- a/waltz-server/src/main/java/com/wepay/waltz/server/WaltzServer.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/WaltzServer.java
@@ -472,7 +472,7 @@ public class WaltzServer {
         REGISTRY.gauge(metricsGroup, "endpoint", (Gauge<String>) () -> endpoint.toString());
         REGISTRY.gauge(metricsGroup, "waltz-server-num-partitions", (Gauge<Integer>) () -> getPartitionIds().size());
         REGISTRY.gauge(metricsGroup, "replica-info", (Gauge<Map<Integer, List<String>>>) () -> getReplicaInfoMap());
-        REGISTRY.gauge(metricsGroup, "waltz_version_id", (Gauge<String>) () -> WaltzInfoParser.getVersion());
+        REGISTRY.gauge(metricsGroup, "waltz-version-id", (Gauge<String>) () -> WaltzInfoParser.getVersion());
     }
 
     private void unregisterMetrics() {

--- a/waltz-storage/src/main/java/com/wepay/waltz/storage/WaltzStorage.java
+++ b/waltz-storage/src/main/java/com/wepay/waltz/storage/WaltzStorage.java
@@ -19,6 +19,7 @@ import com.wepay.riff.util.Logging;
 import com.wepay.waltz.common.metadata.StoreMetadata;
 import com.wepay.waltz.common.metadata.StoreParams;
 import com.wepay.waltz.common.util.Utils;
+import com.wepay.waltz.common.util.WaltzInfoParser;
 import com.wepay.waltz.storage.exception.StorageException;
 import com.wepay.waltz.storage.server.health.Healthcheck;
 import com.wepay.waltz.storage.server.internal.AdminServerHandler;
@@ -256,6 +257,8 @@ public class WaltzStorage {
                 return Collections.emptySet();
             }
         });
+
+        REGISTRY.gauge(metricsGroup, "waltz_version_id", (Gauge<String>) () -> WaltzInfoParser.getVersion());
     }
 
     private void unregisterMetrics() {

--- a/waltz-storage/src/main/java/com/wepay/waltz/storage/WaltzStorage.java
+++ b/waltz-storage/src/main/java/com/wepay/waltz/storage/WaltzStorage.java
@@ -258,7 +258,7 @@ public class WaltzStorage {
             }
         });
 
-        REGISTRY.gauge(metricsGroup, "waltz_version_id", (Gauge<String>) () -> WaltzInfoParser.getVersion());
+        REGISTRY.gauge(metricsGroup, "waltz-version-id", (Gauge<String>) () -> WaltzInfoParser.getVersion());
     }
 
     private void unregisterMetrics() {


### PR DESCRIPTION
Waltz server and storage nodes are currently not aware of the waltz version they are using. This pull request takes care of passing the waltz version at build time from Gradle to waltz server and storage nodes at runtime. The information is also passed to jetty metrics for future display of that information in Grafana.