### PR TITLE
Add guard against mock driver if not in unit test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ project.ext {
     assertjVersion = '3.8.0'
     zkToolsVersion = '0.7.1'
     yamlVersion = '1.20'
-    riffVersion = '2.4.3'
+    riffVersion = '2.4.4'
     jacksonVersion = '2.9.6'
     jettyVersion = '9.4.12.v20180830'
     mainClass = 'Main'


### PR DESCRIPTION
The Waltz mock driver has not been build to be used in test environments, it is to be used specifically for unit tests.
This pull request aims at adding a guard against developers using the Waltz mock driver outside a unit test scope. 