### PR TITLE
Unregister waltz-version metric and server and storage node shutdown

### DIFF
--- a/waltz-server/src/main/java/com/wepay/waltz/server/WaltzServer.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/WaltzServer.java
@@ -483,6 +483,7 @@ public class WaltzServer {
         REGISTRY.remove(metricsGroup, "endpoint");
         REGISTRY.remove(metricsGroup, "waltz-server-num-partitions");
         REGISTRY.remove(metricsGroup, "replica-info");
+        REGISTRY.remove(metricsGroup, "waltz-version-id");
     }
 
     private Map<Integer, List<String>> getReplicaInfoMap() {

--- a/waltz-storage/src/main/java/com/wepay/waltz/storage/WaltzStorage.java
+++ b/waltz-storage/src/main/java/com/wepay/waltz/storage/WaltzStorage.java
@@ -264,5 +264,6 @@ public class WaltzStorage {
     private void unregisterMetrics() {
         REGISTRY.remove(metricsGroup, "waltz-storage-num-partitions");
         REGISTRY.remove(metricsGroup, "waltz-storage-partition-ids");
+        REGISTRY.remove(metricsGroup, "waltz-version-id");
     }
 }


### PR DESCRIPTION
Fix a bug: waltz-version-id metric should be unregistered with other metrics on server and storage shutdown