### PR TITLE
add guard against mock driver if not in unit test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ project.ext {
     assertjVersion = '3.8.0'
     zkToolsVersion = '0.7.1'
     yamlVersion = '1.20'
-    riffVersion = '2.4.3'
+    riffVersion = '2.4.4'
     jacksonVersion = '2.9.6'
     jettyVersion = '9.4.12.v20180830'
     mainClass = 'Main'

--- a/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClientConfig.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClientConfig.java
@@ -5,7 +5,6 @@ import com.wepay.riff.config.validator.Validator;
 import com.wepay.riff.network.SSLConfig;
 import com.wepay.riff.config.AbstractConfig;
 
-import java.security.InvalidKeyException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -128,4 +127,3 @@ public class WaltzClientConfig extends AbstractConfig {
         return false;
     }
 }
-

--- a/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClientConfig.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClientConfig.java
@@ -55,9 +55,9 @@ public class WaltzClientConfig extends AbstractConfig {
     /** Default value for {@link #MOCK_DRIVER} config. */
     public static final Object DEFAULT_MOCK_DRIVER = null;
 
-    public static final Validator mockDriverValidator = (key, value) -> {
+    private static final Validator mockDriverValidator = (key, value) -> {
         if (!key.equals(MOCK_DRIVER)) {
-            throw new ConfigException("Expecting MOCK_DRIVER key. Instead got " + key);
+            throw new ConfigException("Expecting " + MOCK_DRIVER + " key. Instead got " + key);
         }
 
         if (value != null && !isJUnitTest()) {
@@ -65,7 +65,7 @@ public class WaltzClientConfig extends AbstractConfig {
         }
     };
 
-    public static final Parser mockDriverParser = new Parser(null);
+    private static final Parser mockDriverParser = new Parser(null);
 
     private static final HashMap<String, Parser> parsers = new HashMap<>();
 
@@ -118,7 +118,7 @@ public class WaltzClientConfig extends AbstractConfig {
      * Checks if code is running from a unit test
      * @return true if yes, false otherwise
      */
-    public static boolean isJUnitTest() {
+    private static boolean isJUnitTest() {
         for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
             if (element.getClassName().startsWith("org.junit.")) {
                 return true;


### PR DESCRIPTION
The Waltz mock driver has not been build to be used in test environments, it is to be used specifically for unit tests.
This pull request aims at adding a guard against developers using the Waltz mock driver outside a unit test scope.