### PR TITLE
allow multiple partitions in a test cluster

### DIFF
--- a/bin/docker/add-storage.sh
+++ b/bin/docker/add-storage.sh
@@ -16,15 +16,30 @@ TOOLSCONFIG=config/local-docker/waltz-tools.yml
 ZKCLI=com.wepay.waltz.tools.zk.ZooKeeperCli
 STORAGECLI=com.wepay.waltz.tools.storage.StorageCli
 
+numPartitions=${WALTZ_TEST_CLUSTER_NUM_PARTITIONS:-1}
+
 echo "----- adding a storage to the cluster -----"
 
 java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI add-storage-node -c $TOOLSCONFIG -s waltz-storage:55280 -a 55281 -g 0
 echo "...a storage node added the cluster"
 
-java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI assign-partition -c $TOOLSCONFIG -s waltz-storage:55280 -p 0
-echo "...a partition assigned to the storage node"
+echo "----- assigning partitions to the storage -----"
+partitionId=0
+while [ $partitionId -lt $numPartitions ]
+do
+    java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI assign-partition -c $TOOLSCONFIG -s waltz-storage:55280 -p $partitionId
+    echo "...a partition [$partitionId] assigned to the storage node"
+    partitionId=$[$partitionId + 1]
+done
 
 until nc -z localhost 55281; do echo "Waiting for Waltz storage to start..."; sleep 1; done
 
-java $JVMOPTS -cp ${CLASSPATH#:} $STORAGECLI add-partition -c $TOOLSCONFIG -s localhost:55281 -p 0
-echo "...a partition added to the storage"
+echo "----- adding partitions to the storage -----"
+partitionId=0
+while [ $partitionId -lt $numPartitions ]
+do
+    java $JVMOPTS -cp ${CLASSPATH#:} $STORAGECLI add-partition -c $TOOLSCONFIG -s localhost:55281 -p $partitionId
+    echo "...partition [$partitionId] added to the storage"
+    partitionId=$[$partitionId + 1]
+done
+

--- a/bin/docker/cluster.sh
+++ b/bin/docker/cluster.sh
@@ -16,6 +16,7 @@ JVMOPTS=-Dlog4j.configuration=file:config/log4j.properties
 TOOLSCONFIG=config/local-docker/waltz-tools.yml
 ZKCLI=com.wepay.waltz.tools.zk.ZooKeeperCli
 
+numPartitions=${WALTZ_TEST_CLUSTER_NUM_PARTITIONS:-1}
 clusterKey=$(java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI show-cluster-key -c $TOOLSCONFIG)
 
 case $cmd in
@@ -26,16 +27,14 @@ case $cmd in
         else
             echo "----- creating a cluster -----"
 
-            java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI create -c $TOOLSCONFIG -n waltz_cluster -p 1
+            java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI create -c $TOOLSCONFIG -n waltz_cluster -p $numPartitions
             echo "waltz cluster created"
         fi
-
-        clusterKey=$(java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI show-cluster-key -c $TOOLSCONFIG)
 
         mkdir -p build/config
 
         cp config/local-docker/waltz-server.yml build/config/waltz-server.yml
-        sed -e "s/<<clusterKey>>/$clusterKey/" config/local-docker/waltz-storage.yml > build/config/waltz-storage.yml
+        cp config/local-docker/waltz-storage.yml build/config/waltz-storage.yml
 
         echo "config files are generated in build/config"
         ;;


### PR DESCRIPTION
This allows creation of a test cluster with multiple partitions.
Set the environment variable `WALTZ_TEST_CLUSTER_NUM_PARTITIONS` to the desired number of partitions before creating a test cluster (`bin/test-cluster.sh start`).

**Example**
```
export WALTZ_TEST_CLUSTER_NUM_PARTITIONS=5
bin/test-cluster.sh start
```
This creates a test cluster with five partitions.
