### PR TITLE
ZooKeeperCli assign/unassign multiple partitions

### DIFF
--- a/waltz-common/src/main/java/com/wepay/waltz/common/metadata/StoreMetadata.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/metadata/StoreMetadata.java
@@ -360,6 +360,7 @@ public class StoreMetadata {
                 );
             }
 
+            // create newReplicas including partitions to add
             Map<String, int[]> newReplicas = assignPartitions(partitions, storage, replicas);
 
             // update Znode with new replicaAssignments.replicas

--- a/waltz-common/src/main/java/com/wepay/waltz/common/metadata/StoreMetadata.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/metadata/StoreMetadata.java
@@ -578,11 +578,11 @@ public class StoreMetadata {
         int[] curPartitions = replicas.get(storage);
         Set<Integer> partitions = Arrays.stream(curPartitions).boxed().collect(Collectors.toCollection(HashSet::new));
 
-        for (Integer partitionToAssign : partitionsToAssign) {
+        for (Integer partition : partitionsToAssign) {
             // check if the storage contains the partition to assign
-            if (partitions.containsAll(partitionsToAssign)) {
+            if (partitions.contains(partition)) {
                 throw new IllegalArgumentException(
-                    String.format("Partition %s already exists in the storage node.", partitionToAssign)
+                    String.format("Partition %s already exists in the storage node.", partition)
                 );
             }
         }
@@ -617,11 +617,11 @@ public class StoreMetadata {
         int[] curPartitions = replicas.get(storage);
         Set<Integer> partitions = Arrays.stream(curPartitions).boxed().collect(Collectors.toCollection(HashSet::new));
 
-        for (Integer partitionToUnassign : partitionsToUnassign) {
+        for (Integer partition : partitionsToUnassign) {
             // check if the storage contains the partition to un-assign
-            if (!partitions.contains(partitionToUnassign)) {
+            if (!partitions.contains(partition)) {
                 throw new IllegalArgumentException(
-                    String.format("Partition %s does not exist in the storage node.", partitionToUnassign)
+                    String.format("Partition %s does not exist in the storage node.", partition)
                 );
             }
         }

--- a/waltz-server/src/test/java/com/wepay/waltz/store/internal/StoreImplTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/store/internal/StoreImplTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class StoreImplTest {
     private static final int NUM_REPLICAS = 3;
@@ -81,9 +82,8 @@ public class StoreImplTest {
 
             // Remove all partitions from the first storage node.
             StoreMetadata storeMetadata = new StoreMetadata(zkClient, new ZNode(root, StoreMetadata.STORE_ZNODE_NAME));
-            for (int partitionId = 0; partitionId < CLUSTER_NUM_PARTITIONS; partitionId++) {
-                storeMetadata.removePartition(partitionId, helper.getStorageConnectString(0));
-            }
+            List<Integer> partitions = IntStream.range(0, CLUSTER_NUM_PARTITIONS).boxed().collect(Collectors.toList());
+            storeMetadata.removePartitions(partitions, helper.getStorageConnectString(0));
 
             // Wait for recovery and replica states updates to ZK.
             Thread.sleep(1000);

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/CliUtils.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/CliUtils.java
@@ -4,7 +4,15 @@ import com.wepay.waltz.client.Transaction;
 import com.wepay.waltz.client.WaltzClient;
 import com.wepay.waltz.client.WaltzClientCallbacks;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
 public final class CliUtils {
+
+    private CliUtils() { }
 
     /**
      * A transaction callback to help construct {@link WaltzClient}. It is dummy because
@@ -24,5 +32,34 @@ public final class CliUtils {
         @Override
         public void uncaughtException(int partitionId, long transactionId, Throwable exception) {
         }
+    }
+
+    /**
+     * Given a String containing comma-separated integer ranges, expands those ranges, de-duplicates,
+     * and returns as a List.
+     * For "0-2,3,4-5", returns [0,1,2,3,4,5]
+     * @param rangesString Integer ranges as a String
+     * @return expanded ranges as a {@link List}
+     */
+    public static List<Integer> parseIntRanges(String rangesString) {
+        if (rangesString == null || rangesString.isEmpty()) {
+            throw new IllegalArgumentException("Invalid input " + rangesString);
+        }
+
+        Set<Integer> partitions = new HashSet<>();
+        String[] ranges = rangesString.split(",");
+
+        for (String range : ranges) {
+            if (range.contains("-")) {
+                int min = Integer.parseInt(range.split("-")[0]);
+                int max = Integer.parseInt(range.split("-")[1]);
+                IntStream.rangeClosed(min, max).forEach(partitions::add);
+
+            } else {
+                partitions.add(Integer.parseInt(range));
+            }
+        }
+
+        return new ArrayList<>(partitions);
     }
 }

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
@@ -637,8 +637,8 @@ public final class ZooKeeperCli extends SubcommandCli {
      * The {@code Assign} command assign partition to storage node.
      */
     private static final class Assign extends Cli {
-        private static final String NAME = "assign-partitions";
-        private static final String DESCRIPTION = "Assign a partition to a storage node.";
+        private static final String NAME = "assign-partition";
+        private static final String DESCRIPTION = "Assign a partition or multiple partitions to a storage node.";
 
         private Assign(String[] args) {
             super(args);
@@ -648,7 +648,7 @@ public final class ZooKeeperCli extends SubcommandCli {
         protected void configureOptions(Options options) {
             Option partitionOption = Option.builder("p")
                     .longOpt("partition")
-                    .desc("Specify the partition to assign, or multiple partitions as 1-6,7,12-16,...")
+                    .desc("Specify the partition to assign or multiple partitions as comma-separated int ranges such as 0-6,7,10-16")
                     .hasArg()
                     .build();
             Option storageOption = Option.builder("s")
@@ -711,8 +711,8 @@ public final class ZooKeeperCli extends SubcommandCli {
      * The {@code Unassign} command un-assign partition from storage node.
      */
     private static final class Unassign extends Cli {
-        private static final String NAME = "unassign-partitions";
-        private static final String DESCRIPTION = "Un-assign a partition from a storage node.";
+        private static final String NAME = "unassign-partition";
+        private static final String DESCRIPTION = "Un-assign a partition or multiple partitions from a storage node";
 
         private Unassign(String[] args) {
             super(args);
@@ -722,7 +722,7 @@ public final class ZooKeeperCli extends SubcommandCli {
         protected void configureOptions(Options options) {
             Option partitionOption = Option.builder("p")
                     .longOpt("partition")
-                    .desc("Specify the partition to un-assign, or multiple partitions as 1-6,7,12-16,...")
+                    .desc("Specify the partition to un-assign or multiple partitions as comma-separated int ranges such as 0-6,7,10-16")
                     .hasArg()
                     .build();
             Option storageOption = Option.builder("s")

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
@@ -13,6 +13,7 @@ import com.wepay.waltz.common.metadata.ReplicaState;
 import com.wepay.waltz.common.metadata.StoreMetadata;
 import com.wepay.waltz.common.metadata.StoreParams;
 import com.wepay.waltz.tools.CliConfig;
+import com.wepay.waltz.tools.CliUtils;
 import com.wepay.zktools.clustermgr.ClusterManager;
 import com.wepay.zktools.clustermgr.internal.ClusterManagerImpl;
 import com.wepay.zktools.clustermgr.internal.ClusterParams;
@@ -31,6 +32,7 @@ import org.apache.zookeeper.KeeperException;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -635,7 +637,7 @@ public final class ZooKeeperCli extends SubcommandCli {
      * The {@code Assign} command assign partition to storage node.
      */
     private static final class Assign extends Cli {
-        private static final String NAME = "assign-partition";
+        private static final String NAME = "assign-partitions";
         private static final String DESCRIPTION = "Assign a partition to a storage node.";
 
         private Assign(String[] args) {
@@ -646,7 +648,7 @@ public final class ZooKeeperCli extends SubcommandCli {
         protected void configureOptions(Options options) {
             Option partitionOption = Option.builder("p")
                     .longOpt("partition")
-                    .desc("Specify the partition to assign")
+                    .desc("Specify the partition to assign, or multiple partitions as 1-6,7,12-16,...")
                     .hasArg()
                     .build();
             Option storageOption = Option.builder("s")
@@ -682,11 +684,11 @@ public final class ZooKeeperCli extends SubcommandCli {
 
                 zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
-                int partitionId = Integer.parseInt(cmd.getOptionValue("partition"));
-                String storage = cmd.getOptionValue("storage");
+                List<Integer> partitions = CliUtils.parseIntRanges(cmd.getOptionValue("partition"));
 
+                String storage = cmd.getOptionValue("storage");
                 StoreMetadata storeMetadata = new StoreMetadata(zkClient, new ZNode(root, StoreMetadata.STORE_ZNODE_NAME));
-                storeMetadata.addPartition(partitionId, storage);
+                storeMetadata.addPartitions(partitions, storage);
             } catch (Exception e) {
                 if (zkClient != null) {
                     zkClient.close();
@@ -709,7 +711,7 @@ public final class ZooKeeperCli extends SubcommandCli {
      * The {@code Unassign} command un-assign partition from storage node.
      */
     private static final class Unassign extends Cli {
-        private static final String NAME = "unassign-partition";
+        private static final String NAME = "unassign-partitions";
         private static final String DESCRIPTION = "Un-assign a partition from a storage node.";
 
         private Unassign(String[] args) {
@@ -720,7 +722,7 @@ public final class ZooKeeperCli extends SubcommandCli {
         protected void configureOptions(Options options) {
             Option partitionOption = Option.builder("p")
                     .longOpt("partition")
-                    .desc("Specify the partition to un-assign")
+                    .desc("Specify the partition to un-assign, or multiple partitions as 1-6,7,12-16,...")
                     .hasArg()
                     .build();
             Option storageOption = Option.builder("s")
@@ -756,11 +758,11 @@ public final class ZooKeeperCli extends SubcommandCli {
 
                 zkClient = new ZooKeeperClientImpl(zookeeperHostPorts, zkSessionTimeout, zkConnectTimeout);
                 ZNode root = new ZNode(zkRoot);
-                int partition = Integer.parseInt(cmd.getOptionValue("partition"));
+                List<Integer> partitions = CliUtils.parseIntRanges(cmd.getOptionValue("partition"));
                 String storage = cmd.getOptionValue("storage");
 
                 StoreMetadata storeMetadata = new StoreMetadata(zkClient, new ZNode(root, StoreMetadata.STORE_ZNODE_NAME));
-                storeMetadata.removePartition(partition, storage);
+                storeMetadata.removePartitions(partitions, storage);
             } catch (Exception e) {
                 if (zkClient != null) {
                     zkClient.close();

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/zk/ZooKeeperCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/zk/ZooKeeperCliTest.java
@@ -374,7 +374,7 @@ public final class ZooKeeperCliTest {
     }
 
     @Test
-    public void testAssignPartitions() throws Exception {
+    public void testAssignPartition() throws Exception {
         ZooKeeperServerRunner zooKeeperServerRunner = new ZooKeeperServerRunner(0);
         String connectString = zooKeeperServerRunner.start();
         String configFilePath = IntegrationTestHelper.createYamlConfigFile(DIR_NAME, CONFIG_FILE_NAME, createProperties(connectString, CLUSTER_ROOT));

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/zk/ZooKeeperCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/zk/ZooKeeperCliTest.java
@@ -432,7 +432,7 @@ public final class ZooKeeperCliTest {
             addStorageNode(storageNodeToAdd, storageAdminPort, STORAGE_GROUP_1, configFilePath);
 
             String storageNodeAssignTo = storageNodeToAdd;
-            String partitionsToAssign = "0-1,2,3,4-10";
+            String partitionsToAssign = "0-1,2"; // NUM_PARTITIONS
             int[] prevPartitions = zkClient.getData(assignmentNode, ReplicaAssignmentsSerializer.INSTANCE).value.replicas.get(storageNodeAssignTo);
             int prevPartitionSize = prevPartitions.length;
 
@@ -442,9 +442,9 @@ public final class ZooKeeperCliTest {
             int[] currPartitions = zkClient.getData(assignmentNode, ReplicaAssignmentsSerializer.INSTANCE).value.replicas.get(storageNodeAssignTo);
             int currPartitionSize = currPartitions.length;
 
-            assertEquals(prevPartitionSize + 10, currPartitionSize);
+            assertEquals(prevPartitionSize + NUM_PARTITIONS, currPartitionSize);
             assertTrue(Arrays.stream(currPartitions).boxed().collect(Collectors.toSet())
-                .containsAll(IntStream.rangeClosed(0, 10).boxed().collect(Collectors.toList())));
+                .containsAll(IntStream.range(0, NUM_PARTITIONS).boxed().collect(Collectors.toList())));
 
         } finally {
             zooKeeperServerRunner.stop();
@@ -551,7 +551,7 @@ public final class ZooKeeperCliTest {
     }
 
     @Test
-    public void testUnassignMultiplePartition() throws Exception {
+    public void testUnassignMultiplePartitions() throws Exception {
         ZooKeeperServerRunner zooKeeperServerRunner = new ZooKeeperServerRunner(0);
         String connectString = zooKeeperServerRunner.start();
         String configFilePath = IntegrationTestHelper.createYamlConfigFile(DIR_NAME, CONFIG_FILE_NAME, createProperties(connectString, CLUSTER_ROOT));
@@ -564,7 +564,7 @@ public final class ZooKeeperCliTest {
             ZooKeeperCli.Create.createCluster(zkClient, clusterRootZNode, CLUSTER_NAME, NUM_PARTITIONS);
             ZooKeeperCli.Create.createStores(zkClient, clusterRootZNode, NUM_PARTITIONS, STORAGE_GROUP_MAP, STORAGE_CONNECTION_MAP);
 
-            String partitionsToRemove = "0-5,6,7,8-10";
+            String partitionsToRemove = "0-1,2"; // NUM_PARTITIONS
             String storageNodeRemoveFrom = "fakehost0:6000";
 
             int[] prevPartitions = zkClient.getData(assignmentNode, ReplicaAssignmentsSerializer.INSTANCE).value.replicas.get(storageNodeRemoveFrom);
@@ -575,8 +575,8 @@ public final class ZooKeeperCliTest {
             int[] currPartitions = zkClient.getData(assignmentNode, ReplicaAssignmentsSerializer.INSTANCE).value.replicas.get(storageNodeRemoveFrom);
             int currPartitionSize = currPartitions.length;
 
-            assertEquals(prevPartitionSize - 10, currPartitionSize);
-            IntStream.rangeClosed(0, 10).forEach(
+            assertEquals(prevPartitionSize - NUM_PARTITIONS, currPartitionSize);
+            IntStream.range(0, NUM_PARTITIONS).forEach(
                 partitionToRemove -> assertTrue(!Arrays.stream(currPartitions).boxed().collect(Collectors.toSet())
                     .contains(partitionToRemove))
             );


### PR DESCRIPTION
- Updated assign-partition, and unassign-partition commands in ZooKeeperCli to accept multiple partitions as comma separated integer ranges.
- Changes in partitions set of the given storage node are sent to ZooKeeper as a single update thus minimizing the number of watcher notifications to the Waltz Server.
- `-p 0-10,11,12-20` assigns/unassigns to a given storage node all the partitions in [0,20] inclusive.
- `-p 0-511` assigns/unassigns to a given storage node all the partitions in [0,511] inclusive.
- The existing functionality works as is, so `-p 2` assigns/unassigns partition 2.
