### PR TITLE
Move WaltzClient Partition Mounted log from debug to info

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/Partition.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/Partition.java
@@ -216,7 +216,7 @@ public class Partition {
         synchronized (lock) {
             // Make sure the network client is the right one
             if (this.networkClient == networkClient) {
-                logger.debug("partition mounted: {}", this);
+                logger.info("partition mounted: {}", this);
                 this.mounted = true;
                 lock.notifyAll();
             }


### PR DESCRIPTION
-- Moved Partition Mounted log from debug to info.
-- Given the importance of mounting partitions, I think this log serves better at the info level.