### PR TITLE
Update zktools version and waltz minor version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ project.ext {
     slf4jVersion = '1.7.25'
     mockitoVersion = '1.9.5'
     assertjVersion = '3.8.0'
-    zkToolsVersion = '0.7.1'
+    zkToolsVersion = '0.7.2'
     yamlVersion = '1.20'
     riffVersion = '2.4.6'
     jacksonVersion = '2.9.6'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.waltz
 sourceCompatibility=1.8
-version=0.9.0
+version=0.10.0


### PR DESCRIPTION
* Update zktools version to 0.7.2 to include changes in DynamicPartitionAssignmentPolicy https://github.com/wepay/zktools/pull/12.
* Bump up waltz minor version.
