### PR TITLE
Added JMX reporter for the Waltz client metrics.

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/WaltzClient.java
@@ -3,6 +3,7 @@ package com.wepay.waltz.client;
 import com.wepay.riff.metrics.core.Gauge;
 import com.wepay.riff.metrics.core.MetricGroup;
 import com.wepay.riff.metrics.core.MetricRegistry;
+import com.wepay.riff.metrics.jmx.JmxReporter;
 import com.wepay.riff.util.Logging;
 import com.wepay.waltz.client.internal.RpcClient;
 import com.wepay.waltz.client.internal.StreamClient;
@@ -80,6 +81,8 @@ public class WaltzClient {
             longWaitThreshold,
             TimeUnit.MILLISECONDS
         );
+
+        JmxReporter.forRegistry(MetricRegistry.getInstance()).build().start();
 
         registerMetrics();
     }


### PR DESCRIPTION
This pull request adds JMX reporter to Waltz client in order to be able to view the Waltz client metrics in the jconsole and be able to populate it to prometheus for monitoring on Grafana.