### PR TITLE
support of multiple clusters in test-cluster.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.iml
 .gradle/
 build/
+config/local-docker/*/*
 target/
 out/
 logs/

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ This builds the Docker images.
 
 ### Starting test cluster
 
-    bin/test-cluster.sh start
+    bin/test-cluster.sh start <- Start default cluster
+    bin/test-cluster.sh start <cluster_name> <- Start stopped cluster that is been already created
+    bin/test-cluster.sh start <cluster_name> <base_server_port> <base_storage_port> <- Start new cluster of one storage & server node running on provided ports
 
 This creates a user defined docker network `waltz-network` and 
 starts three container, a zookeeper server, a waltz storage node, and a waltz server node in `waltz-network`.
@@ -97,17 +99,17 @@ If the Docker images are not built yet, this script builds them.
 However, it doesn't automatically build a new images even when the source code is modified. 
 You must rebuild images using `distDocker` gradle task.
 
-### Stopping the test cluster
+### Stopping waltz test cluster
 
-    bin/test-cluster.sh stop
+    bin/test-cluster.sh stop <- stop all created clusters
+    bin/test-cluster.sh stop <cluster_name> <- stop cluster with the given cluster name
 
-This stops all three containers. You can resume the cluster using `start` command. All data in zookeeper and storages are preserved.
+This stops waltz containers. You can resume the cluster using `start <cluster_name>` command. All data in zookeeper and storages are preserved.
 
 ### Destroying the test cluster
 
-    bin/test-cluster.sh clean
-    
-This will remove all three containers, thus removes all data.
+    bin/test-cluster.sh clean <- This will remove all waltz containers including zookeeper, thus removes all data.
+    bin/test-cluster.sh clean <cluster_name> <- This will remove all two containers belonging to the same cluster. Zookeeper stays intact.
 
 ### Setting up the test cluster with multiple partitions.
 
@@ -117,7 +119,7 @@ the environment variable WALTZ_TEST_CLUSTER_NUM_PARTITIONS to the desired number
 For example, to create the test cluster with five partitions, do the following.
 
     export WALTZ_TEST_CLUSTER_NUM_PARTITIONS=5
-    bin/test-cluster.sh start 1
+    bin/test-cluster.sh start
 
 ### Running DemoBankApp
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ We implemented shell scripts to run a Waltz cluster in local Docker containers f
 
 This builds the Docker images.
 
-### Starting the test cluster
+### Starting 1 test cluster
 
-    bin/test-cluster.sh start
+    bin/test-cluster.sh start 1
 
 This creates a user defined docker network `waltz-network` and 
 starts three container, a zookeeper server, a waltz storage node, and a waltz server node in `waltz-network`.
@@ -117,7 +117,7 @@ the environment variable WALTZ_TEST_CLUSTER_NUM_PARTITIONS to the desired number
 For example, to create the test cluster with five partitions, do the following.
 
     export WALTZ_TEST_CLUSTER_NUM_PARTITIONS=5
-    bin/test-cluster.sh start
+    bin/test-cluster.sh start 1
 
 ### Running DemoBankApp
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ We implemented shell scripts to run a Waltz cluster in local Docker containers f
 
 This builds the Docker images.
 
-### Starting 1 test cluster
+### Starting test cluster
 
-    bin/test-cluster.sh start 1
+    bin/test-cluster.sh start
 
 This creates a user defined docker network `waltz-network` and 
 starts three container, a zookeeper server, a waltz storage node, and a waltz server node in `waltz-network`.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ This stops waltz containers. You can resume the cluster using `start <cluster_na
     bin/test-cluster.sh clean <- This will remove all waltz containers including zookeeper, thus removes all data.
     bin/test-cluster.sh clean <cluster_name> <- This will remove all two containers belonging to the same cluster. Zookeeper stays intact.
 
+### Restarting the test cluster
+
+    bin/test-cluster.sh restart <- This will restart all waltz containers and regenerate config files (equivalent to stop, start).
+    bin/test-cluster.sh restart <cluster_name> <- This will restart all two containers belonging to the same cluster and regenerate config files.
+
 ### Setting up the test cluster with multiple partitions.
 
 The test cluster is set up with a single partition by default.

--- a/bin/docker/add-storage.sh
+++ b/bin/docker/add-storage.sh
@@ -22,14 +22,14 @@ numPartitions=${WALTZ_TEST_CLUSTER_NUM_PARTITIONS:-1}
 
 echo "----- adding a storage to the cluster -----"
 
-java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI add-storage-node -c $TOOLSCONFIG -s waltz-storage-"$1":"$base_port" -a "$admin_port" -g 0
+java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI add-storage-node -c $TOOLSCONFIG -s waltz_ledger_store_"$1":"$base_port" -a "$admin_port" -g 0
 echo "...a storage node added the cluster"
 
 echo "----- assigning partitions to the storage -----"
 partitionId=0
 while [ $partitionId -lt $numPartitions ]
 do
-    java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI assign-partition -c $TOOLSCONFIG -s waltz-storage-"$1":"$base_port" -p $partitionId
+    java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI assign-partition -c $TOOLSCONFIG -s waltz_ledger_store_"$1":"$base_port" -p $partitionId
     echo "...a partition [$partitionId] assigned to the storage node"
     partitionId=$[$partitionId + 1]
 done

--- a/bin/docker/add-storage.sh
+++ b/bin/docker/add-storage.sh
@@ -3,6 +3,8 @@
 DIR=$(dirname $0)
 
 $DIR/../../gradlew --console=plain -q copyLibs
+base_port="$2"
+admin_port=$(($2 + 1))
 
 CLASSPATH=""
 for file in waltz-tools/build/libs/*.jar;
@@ -12,7 +14,7 @@ done
 
 JVMOPTS=-Dlog4j.configuration=file:config/log4j.properties
 
-TOOLSCONFIG=config/local-docker/waltz-tools.yml
+TOOLSCONFIG=build/config-"$1"/waltz-tools.yml
 ZKCLI=com.wepay.waltz.tools.zk.ZooKeeperCli
 STORAGECLI=com.wepay.waltz.tools.storage.StorageCli
 
@@ -20,25 +22,25 @@ numPartitions=${WALTZ_TEST_CLUSTER_NUM_PARTITIONS:-1}
 
 echo "----- adding a storage to the cluster -----"
 
-java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI add-storage-node -c $TOOLSCONFIG -s waltz-storage:55280 -a 55281 -g 0
+java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI add-storage-node -c $TOOLSCONFIG -s waltz-storage-"$1":"$base_port" -a "$admin_port" -g 0
 echo "...a storage node added the cluster"
 
 echo "----- assigning partitions to the storage -----"
 partitionId=0
 while [ $partitionId -lt $numPartitions ]
 do
-    java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI assign-partition -c $TOOLSCONFIG -s waltz-storage:55280 -p $partitionId
+    java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI assign-partition -c $TOOLSCONFIG -s waltz-storage-"$1":"$base_port" -p $partitionId
     echo "...a partition [$partitionId] assigned to the storage node"
     partitionId=$[$partitionId + 1]
 done
 
-until nc -z localhost 55281; do echo "Waiting for Waltz storage to start..."; sleep 1; done
+until nc -z localhost "$admin_port"; do echo "Waiting for Waltz storage to start..."; sleep 1; done
 
 echo "----- adding partitions to the storage -----"
 partitionId=0
 while [ $partitionId -lt $numPartitions ]
 do
-    java $JVMOPTS -cp ${CLASSPATH#:} $STORAGECLI add-partition -c $TOOLSCONFIG -s localhost:55281 -p $partitionId
+    java $JVMOPTS -cp ${CLASSPATH#:} $STORAGECLI add-partition -c $TOOLSCONFIG -s localhost:"$admin_port" -p $partitionId
     echo "...partition [$partitionId] added to the storage"
     partitionId=$[$partitionId + 1]
 done

--- a/bin/docker/add-storage.sh
+++ b/bin/docker/add-storage.sh
@@ -14,7 +14,7 @@ done
 
 JVMOPTS=-Dlog4j.configuration=file:config/log4j.properties
 
-TOOLSCONFIG=build/config-"$1"/waltz-tools.yml
+TOOLSCONFIG=config/local-docker/"$1"/waltz-tools.yml
 ZKCLI=com.wepay.waltz.tools.zk.ZooKeeperCli
 STORAGECLI=com.wepay.waltz.tools.storage.StorageCli
 
@@ -22,14 +22,14 @@ numPartitions=${WALTZ_TEST_CLUSTER_NUM_PARTITIONS:-1}
 
 echo "----- adding a storage to the cluster -----"
 
-java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI add-storage-node -c $TOOLSCONFIG -s waltz_ledger_store_"$1":"$base_port" -a "$admin_port" -g 0
+java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI add-storage-node -c $TOOLSCONFIG -s "$1":"$base_port" -a "$admin_port" -g 0
 echo "...a storage node added the cluster"
 
 echo "----- assigning partitions to the storage -----"
 partitionId=0
 while [ $partitionId -lt $numPartitions ]
 do
-    java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI assign-partition -c $TOOLSCONFIG -s waltz_ledger_store_"$1":"$base_port" -p $partitionId
+    java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI assign-partition -c $TOOLSCONFIG -s "$1":"$base_port" -p $partitionId
     echo "...a partition [$partitionId] assigned to the storage node"
     partitionId=$[$partitionId + 1]
 done

--- a/bin/docker/cluster-config-files.sh
+++ b/bin/docker/cluster-config-files.sh
@@ -6,13 +6,13 @@ storage_base_port=$3
 storage_admin_port=$((storage_base_port + 1))
 storage_jetty_port=$((storage_base_port + 2))
 storage_directory="/waltz_storage/"
-cluster_name="/waltz_cluster$4"
+cluster_name="/$1"
 
-mkdir -p build/config-"$1"
+mkdir -p config/local-docker/"$1"
 
 sed  \
     "s|\(cluster.root:[ ]*\)\(.*$\)|\1$cluster_name|;" \
-    config/local-docker/waltz-tools.yml > build/config-"$1"/waltz-tools.yml
+    config/local-docker/waltz-tools.yml > config/local-docker/"$1"/waltz-tools.yml
 
 sed \
     "s|\(storage.port:[ ]*\)\([0-9]*\)|\1$storage_base_port|;
@@ -20,12 +20,12 @@ sed \
     s|\(jetty.port:[ ]*\)\([0-9]*\)|\1$storage_jetty_port|;
     s|\(storage.directory:[ ]*\)\(.*$\)|\1$storage_directory|;
     s|\(cluster.root:[ ]*\)\(.*$\)|\1$cluster_name|;" \
-    config/local-docker/waltz-storage.yml > build/config-"$1"/waltz-storage.yml
+    config/local-docker/waltz-storage.yml > config/local-docker/"$1"/waltz-storage.yml
 
 sed \
     "s|\(server.port:[ ]*\)\([0-9]*\)|\1$server_base_port|;
     s|\(jetty.port:[ ]*\)\([0-9]*\)|\1$server_jetty_port|;
     s|\(cluster.root:[ ]*\)\(.*$\)|\1$cluster_name|;" \
-    config/local-docker/waltz-server.yml > build/config-"$1"/waltz-server.yml
+    config/local-docker/waltz-server.yml > config/local-docker/"$1"/waltz-server.yml
 
-echo "config files are generated in build/config-$1"
+echo "config files are generated in config/local-docker/$1"

--- a/bin/docker/cluster-config-files.sh
+++ b/bin/docker/cluster-config-files.sh
@@ -1,18 +1,18 @@
 #!/bin/sh
 
-cluster_name="/waltz_cluster_$1"
 server_base_port=$2
 server_jetty_port=$((server_base_port + 2))
 storage_base_port=$3
 storage_admin_port=$((storage_base_port + 1))
 storage_jetty_port=$((storage_base_port + 2))
 storage_directory="/waltz_storage/"
+cluster_name="/waltz_cluster$4"
 
-mkdir -p build/config-$1
+mkdir -p build/config-"$1"
 
 sed  \
     "s|\(cluster.root:[ ]*\)\(.*$\)|\1$cluster_name|;" \
-    config/local-docker/waltz-tools.yml > build/config-$1/waltz-tools.yml
+    config/local-docker/waltz-tools.yml > build/config-"$1"/waltz-tools.yml
 
 sed \
     "s|\(storage.port:[ ]*\)\([0-9]*\)|\1$storage_base_port|;
@@ -20,12 +20,12 @@ sed \
     s|\(jetty.port:[ ]*\)\([0-9]*\)|\1$storage_jetty_port|;
     s|\(storage.directory:[ ]*\)\(.*$\)|\1$storage_directory|;
     s|\(cluster.root:[ ]*\)\(.*$\)|\1$cluster_name|;" \
-    config/local-docker/waltz-storage.yml > build/config-$1/waltz-storage.yml
+    config/local-docker/waltz-storage.yml > build/config-"$1"/waltz-storage.yml
 
 sed \
     "s|\(server.port:[ ]*\)\([0-9]*\)|\1$server_base_port|;
     s|\(jetty.port:[ ]*\)\([0-9]*\)|\1$server_jetty_port|;
     s|\(cluster.root:[ ]*\)\(.*$\)|\1$cluster_name|;" \
-    config/local-docker/waltz-server.yml > build/config-$1/waltz-server.yml
+    config/local-docker/waltz-server.yml > build/config-"$1"/waltz-server.yml
 
 echo "config files are generated in build/config-$1"

--- a/bin/docker/cluster-config-files.sh
+++ b/bin/docker/cluster-config-files.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+cluster_name="/waltz_cluster_$1"
+server_base_port=$2
+server_jetty_port=$((server_base_port + 2))
+storage_base_port=$3
+storage_admin_port=$((storage_base_port + 1))
+storage_jetty_port=$((storage_base_port + 2))
+storage_directory="/waltz_storage/"
+
+mkdir -p build/config-$1
+
+sed  \
+    "s|\(cluster.root:[ ]*\)\(.*$\)|\1$cluster_name|;" \
+    config/local-docker/waltz-tools.yml > build/config-$1/waltz-tools.yml
+
+sed \
+    "s|\(storage.port:[ ]*\)\([0-9]*\)|\1$storage_base_port|;
+    s|\(admin.port:[ ]*\)\([0-9]*\)|\1$storage_admin_port|;
+    s|\(jetty.port:[ ]*\)\([0-9]*\)|\1$storage_jetty_port|;
+    s|\(storage.directory:[ ]*\)\(.*$\)|\1$storage_directory|;
+    s|\(cluster.root:[ ]*\)\(.*$\)|\1$cluster_name|;" \
+    config/local-docker/waltz-storage.yml > build/config-$1/waltz-storage.yml
+
+sed \
+    "s|\(server.port:[ ]*\)\([0-9]*\)|\1$server_base_port|;
+    s|\(jetty.port:[ ]*\)\([0-9]*\)|\1$server_jetty_port|;
+    s|\(cluster.root:[ ]*\)\(.*$\)|\1$cluster_name|;" \
+    config/local-docker/waltz-server.yml > build/config-$1/waltz-server.yml
+
+echo "config files are generated in build/config-$1"

--- a/bin/docker/cluster.sh
+++ b/bin/docker/cluster.sh
@@ -2,6 +2,7 @@
 
 DIR=$(dirname $0)
 cmd=$1
+ending=$2
 
 $DIR/../../gradlew --console=plain -q copyLibs
 
@@ -13,7 +14,7 @@ done
 
 JVMOPTS=-Dlog4j.configuration=file:config/log4j.properties
 
-TOOLSCONFIG=config/local-docker/waltz-tools.yml
+TOOLSCONFIG=build/config-"$ending"/waltz-tools.yml
 ZKCLI=com.wepay.waltz.tools.zk.ZooKeeperCli
 
 numPartitions=${WALTZ_TEST_CLUSTER_NUM_PARTITIONS:-1}
@@ -27,22 +28,15 @@ case $cmd in
         else
             echo "----- creating a cluster -----"
 
-            java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI create -c $TOOLSCONFIG -n waltz_cluster -p $numPartitions
+            java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI create -c $TOOLSCONFIG -n waltz_cluster_"$ending" -p $numPartitions
             echo "waltz cluster created"
         fi
-
-        mkdir -p build/config
-
-        cp config/local-docker/waltz-server.yml build/config/waltz-server.yml
-        cp config/local-docker/waltz-storage.yml build/config/waltz-storage.yml
-
-        echo "config files are generated in build/config"
         ;;
 
     delete)
         if [ "$clusterKey" != "" ]
         then
-            java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI delete -c $TOOLSCONFIG -n waltz_cluster
+            java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI delete -c $TOOLSCONFIG -n waltz_cluster_"$ending"
             echo "cluster deleted"
         fi
         ;;

--- a/bin/docker/cluster.sh
+++ b/bin/docker/cluster.sh
@@ -24,12 +24,12 @@ case $cmd in
     create)
         if [ "${clusterKey}" != "" ]
         then
-            echo "----- cluster already created -----"
+            echo "----- cluster $clusterName already created -----"
         else
-            echo "----- creating a cluster -----"
+            echo "----- creating $clusterName cluster -----"
 
             java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI create -c $TOOLSCONFIG -n "$clusterName" -p $numPartitions
-            echo "waltz cluster created"
+            echo "$clusterName cluster created"
         fi
         ;;
 

--- a/bin/docker/cluster.sh
+++ b/bin/docker/cluster.sh
@@ -2,7 +2,7 @@
 
 DIR=$(dirname $0)
 cmd=$1
-ending=$2
+clusterName=$2
 
 $DIR/../../gradlew --console=plain -q copyLibs
 
@@ -14,7 +14,7 @@ done
 
 JVMOPTS=-Dlog4j.configuration=file:config/log4j.properties
 
-TOOLSCONFIG=build/config-"$ending"/waltz-tools.yml
+TOOLSCONFIG=config/local-docker/"$clusterName"/waltz-tools.yml
 ZKCLI=com.wepay.waltz.tools.zk.ZooKeeperCli
 
 numPartitions=${WALTZ_TEST_CLUSTER_NUM_PARTITIONS:-1}
@@ -28,7 +28,7 @@ case $cmd in
         else
             echo "----- creating a cluster -----"
 
-            java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI create -c $TOOLSCONFIG -n waltz_cluster_"$ending" -p $numPartitions
+            java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI create -c $TOOLSCONFIG -n "$clusterName" -p $numPartitions
             echo "waltz cluster created"
         fi
         ;;
@@ -36,7 +36,7 @@ case $cmd in
     delete)
         if [ "$clusterKey" != "" ]
         then
-            java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI delete -c $TOOLSCONFIG -n waltz_cluster_"$ending"
+            java $JVMOPTS -cp ${CLASSPATH#:} $ZKCLI delete -c $TOOLSCONFIG -n "$clusterName"
             echo "cluster deleted"
         fi
         ;;

--- a/bin/docker/waltz-server.sh
+++ b/bin/docker/waltz-server.sh
@@ -10,9 +10,9 @@ networkName=waltz-network
 configFolder="$2"
 
 if [ $cmd = "start" ]; then
-    port_lower_bound=$3
-    port_upper_bound=$4
-    ports="$port_lower_bound-$port_upper_bound:$port_lower_bound-$port_upper_bound"
+    portsOccupiedLowerBound=$3
+    portsOccupiedUpperBound=$(($3 + 2))
+    ports="$portsOccupiedLowerBound-$portsOccupiedUpperBound:$portsOccupiedLowerBound-$portsOccupiedUpperBound"
 fi
 
 runContainer() {

--- a/bin/docker/waltz-server.sh
+++ b/bin/docker/waltz-server.sh
@@ -5,9 +5,15 @@ cmd=$1
 
 imageSource=waltz-server:distDocker
 imageName=com.wepay.waltz/waltz-server
-containerName=waltz-server
+containerName=waltz-server-"$2"
 networkName=waltz-network
-ports=55180-55182:55180-55182
+configFolder="config-$2"
+
+if [ $cmd = "start" ]; then
+    port_lower_bound=$3
+    port_upper_bound=$4
+    ports="$port_lower_bound-$port_upper_bound:$port_lower_bound-$port_upper_bound"
+fi
 
 runContainer() {
     local imageId=$(docker images -q ${imageName})
@@ -17,7 +23,7 @@ runContainer() {
     else
         docker run \
             --network=$networkName --net-alias $(hostname) -h $(hostname) -p $ports \
-            --name $containerName -d -v $PWD/build/config:/config/ \
+            --name $containerName -d -v $PWD/build/$configFolder:/config/ \
             $imageId /config/waltz-server.yml
     fi
 }

--- a/bin/docker/waltz-server.sh
+++ b/bin/docker/waltz-server.sh
@@ -5,9 +5,9 @@ cmd=$1
 
 imageSource=waltz-server:distDocker
 imageName=com.wepay.waltz/waltz-server
-containerName=waltz_ledger_server_"$2"
+containerName="$2_server"
 networkName=waltz-network
-configFolder="config-$2"
+configFolder="$2"
 
 if [ $cmd = "start" ]; then
     port_lower_bound=$3
@@ -23,7 +23,7 @@ runContainer() {
     else
         docker run \
             --network=$networkName --net-alias $(hostname) -h $(hostname) -p $ports \
-            --name $containerName -d -v $PWD/build/$configFolder:/config/ \
+            --name $containerName -d -v $PWD/config/local-docker/$configFolder:/config/ \
             $imageId /config/waltz-server.yml
     fi
 }

--- a/bin/docker/waltz-server.sh
+++ b/bin/docker/waltz-server.sh
@@ -5,7 +5,7 @@ cmd=$1
 
 imageSource=waltz-server:distDocker
 imageName=com.wepay.waltz/waltz-server
-containerName=waltz-server-"$2"
+containerName=waltz_ledger_server_"$2"
 networkName=waltz-network
 configFolder="config-$2"
 
@@ -17,7 +17,7 @@ fi
 
 runContainer() {
     local imageId=$(docker images -q ${imageName})
-    if [ "${imageId}" == "" ]
+    if [ "${imageId}" = "" ]
     then
         echo "...image not built correctly"
     else

--- a/bin/docker/waltz-server.sh
+++ b/bin/docker/waltz-server.sh
@@ -10,9 +10,9 @@ networkName=waltz-network
 configFolder="$2"
 
 if [ $cmd = "start" ]; then
-    portsOccupiedLowerBound=$3
-    portsOccupiedUpperBound=$(($3 + 2))
-    ports="$portsOccupiedLowerBound-$portsOccupiedUpperBound:$portsOccupiedLowerBound-$portsOccupiedUpperBound"
+    portsLowerBound=$3
+    portsUpperBound=$(($3 + 2))
+    ports="$portsLowerBound-$portsUpperBound:$portsLowerBound-$portsUpperBound"
 fi
 
 runContainer() {

--- a/bin/docker/waltz-storage.sh
+++ b/bin/docker/waltz-storage.sh
@@ -5,8 +5,8 @@ cmd=$1
 
 imageSource=waltz-storage:distDocker
 imageName=com.wepay.waltz/waltz-storage
-containerName=waltz_ledger_store_$2
-configFolder="config-$2"
+containerName="$2_store"
+configFolder="$2"
 
 networkName=waltz-network
 if [ $cmd = "start" ]; then
@@ -22,7 +22,7 @@ runContainer() {
         echo "...image not built correctly"
     else
         docker run \
-            --network=$networkName -p $ports --name $containerName -d -v $PWD/build/$configFolder:/config/ \
+            --network=$networkName -p $ports --name $containerName -d -v $PWD/config/local-docker/$configFolder:/config/ \
             $imageId /config/waltz-storage.yml
     fi
 }

--- a/bin/docker/waltz-storage.sh
+++ b/bin/docker/waltz-storage.sh
@@ -5,7 +5,7 @@ cmd=$1
 
 imageSource=waltz-storage:distDocker
 imageName=com.wepay.waltz/waltz-storage
-containerName="$2_store"
+containerName="$2_storage"
 configFolder="$2"
 
 networkName=waltz-network

--- a/bin/docker/waltz-storage.sh
+++ b/bin/docker/waltz-storage.sh
@@ -10,9 +10,9 @@ configFolder="$2"
 
 networkName=waltz-network
 if [ $cmd = "start" ]; then
-    port_lower_bound=$3
-    port_upper_bound=$4
-    ports="$port_lower_bound-$port_upper_bound:$port_lower_bound-$port_upper_bound"
+    portsOccupiedLowerBound=$3
+    portsOccupiedUpperBound=$(($3 + 2))
+    ports="$portsOccupiedLowerBound-$portsOccupiedUpperBound:$portsOccupiedLowerBound-$portsOccupiedUpperBound"
 fi
 
 runContainer() {

--- a/bin/docker/waltz-storage.sh
+++ b/bin/docker/waltz-storage.sh
@@ -5,7 +5,7 @@ cmd=$1
 
 imageSource=waltz-storage:distDocker
 imageName=com.wepay.waltz/waltz-storage
-containerName=waltz-storage-$2
+containerName=waltz_ledger_store_$2
 configFolder="config-$2"
 
 networkName=waltz-network
@@ -17,7 +17,7 @@ fi
 
 runContainer() {
     local imageId=$(docker images -q ${imageName})
-    if [ "${imageId}" == "" ]
+    if [ "${imageId}" = "" ]
     then
         echo "...image not built correctly"
     else

--- a/bin/docker/waltz-storage.sh
+++ b/bin/docker/waltz-storage.sh
@@ -10,9 +10,9 @@ configFolder="$2"
 
 networkName=waltz-network
 if [ $cmd = "start" ]; then
-    portsOccupiedLowerBound=$3
-    portsOccupiedUpperBound=$(($3 + 2))
-    ports="$portsOccupiedLowerBound-$portsOccupiedUpperBound:$portsOccupiedLowerBound-$portsOccupiedUpperBound"
+    portsLowerBound=$3
+    portsUpperBound=$(($3 + 2))
+    ports="$portsLowerBound-$portsUpperBound:$portsLowerBound-$portsUpperBound"
 fi
 
 runContainer() {

--- a/bin/docker/waltz-storage.sh
+++ b/bin/docker/waltz-storage.sh
@@ -5,9 +5,15 @@ cmd=$1
 
 imageSource=waltz-storage:distDocker
 imageName=com.wepay.waltz/waltz-storage
-containerName=waltz-storage
+containerName=waltz-storage-$2
+configFolder="config-$2"
+
 networkName=waltz-network
-ports=55280-55282:55280-55282
+if [ $cmd = "start" ]; then
+    port_lower_bound=$3
+    port_upper_bound=$4
+    ports="$port_lower_bound-$port_upper_bound:$port_lower_bound-$port_upper_bound"
+fi
 
 runContainer() {
     local imageId=$(docker images -q ${imageName})
@@ -16,7 +22,7 @@ runContainer() {
         echo "...image not built correctly"
     else
         docker run \
-            --network=$networkName -p $ports --name $containerName -d -v $PWD/build/config:/config/ \
+            --network=$networkName -p $ports --name $containerName -d -v $PWD/build/$configFolder:/config/ \
             $imageId /config/waltz-storage.yml
     fi
 }

--- a/bin/test-cluster.sh
+++ b/bin/test-cluster.sh
@@ -6,64 +6,89 @@ serverPortBase=55180
 storagePortBase=55280
 storagePortsOccupied=3
 serverPortsOccupied=3
+defaultClusterName="default"
 
 # supported commands: start/stop/restart/clean
-# test-cluster.sh start <- initiate network, add 1 new cluster
-# test-cluster.sh stop (0) <- stop all clusters/(stop cluster with given cluster number)
-# test-cluster.sh restart (0) <- restart all clusters/(restart cluster with given cluster number)
-# test-cluster.sh clean (0) <- remove all clusters/(remove cluster with given cluster number)
+# test-cluster.sh start <- initiate network, add a default cluster
+# test-cluster.sh start name1 name2 name3<- initiate network, adds new clusters with the name specified
+# test-cluster.sh stop (nameX) <- stop all clusters/(stop cluster with given cluster number)
+# test-cluster.sh restart (nameX) <- restart all clusters/(restart cluster with given cluster number)
+# test-cluster.sh clean (name1) <- remove all clusters/(remove cluster with given cluster number)
 
 initNetwork() {
     $DIR/docker/create-network.sh
     $DIR/docker/zookeeper.sh start
 }
 
-startCluster() {
-    clusterId=$1
-    echo $clusterId
-    serverPortLowerBound=$((serverPortBase + $clusterId * $serverPortsOccupied))
-    storagePortLowerBound=$(($storagePortBase + $clusterId * $storagePortsOccupied))
-    $DIR/docker/cluster-config-files.sh $clusterId $serverPortLowerBound $storagePortLowerBound
+getClusterId() {
+    clusterName=$1
+    clusterIdNew=$(docker container ls -a --format '{{.Names}}' --filter "name=waltz_ledger_server_*" | wc -l)
+    clusterExists=$(docker container ls -a --format '{{.Names}}' --filter "name=waltz_ledger_server_$clusterName" | wc -l)
+    if [[ "$clusterExists" -gt 0 ]]; then
+        containerId=$(docker container ls -a --format '{{.ID}}' --filter "name=waltz_ledger_server_$clusterName" | head -1)
+        assignedPort=$(docker inspect --format='{{.HostConfig.PortBindings}}' $containerId | grep -o -E '[0-9]+' | head -1)
+        echo $((($assignedPort - $serverPortBase) / $serverPortsOccupied))
+    else
+        echo $clusterIdNew
+    fi
+}
 
-    $DIR/docker/cluster.sh create $clusterId
-    $DIR/docker/waltz-storage.sh start "$clusterId" $storagePortLowerBound $(($storagePortLowerBound + $storagePortsOccupied - 1)) 0
-    $DIR/docker/add-storage.sh $clusterId $storagePortLowerBound
-    $DIR/docker/waltz-server.sh start $clusterId $serverPortLowerBound $(($serverPortLowerBound + $serverPortsOccupied - 1))
-    echo "----- Cluster $clusterId created!"
+startCluster() {
+    clusterName=$1
+    clusterId=$(getClusterId $clusterName)
+    echo "----- Creating waltz_ledger_$clusterName cluster"
+    serverPortLowerBound=$(($serverPortBase + $clusterId * $serverPortsOccupied))
+    storagePortLowerBound=$(($storagePortBase + $clusterId * $storagePortsOccupied))
+    if [ "$clusterName" = "$defaultClusterName" ]; then
+        $DIR/docker/cluster-config-files.sh "$clusterName" $serverPortLowerBound $storagePortLowerBound ""
+    else
+        $DIR/docker/cluster-config-files.sh "$clusterName" $serverPortLowerBound $storagePortLowerBound "_$clusterName"
+    fi
+
+    $DIR/docker/cluster.sh create "$clusterName"
+    $DIR/docker/waltz-storage.sh start "$clusterName" $storagePortLowerBound $(($storagePortLowerBound + $storagePortsOccupied - 1)) 0
+    $DIR/docker/add-storage.sh "$clusterName" $storagePortLowerBound
+    $DIR/docker/waltz-server.sh start "$clusterName" $serverPortLowerBound $(($serverPortLowerBound + $serverPortsOccupied - 1))
+    echo "----- Cluster waltz_ledger_$clusterName created!"
+}
+
+stopCluster() {
+    $DIR/docker/waltz-server.sh stop "$1"
+    $DIR/docker/waltz-storage.sh stop "$1"
 }
 
 stop() {
-    for clusterId in $(docker container ls --format '{{.Names}}' --filter "name=waltz-server-*" | sed 's/^.*-//'); do
-        stopCluster $clusterId
+    for clusterId in $(docker container ls --format '{{.Names}}' --filter "name=waltz_ledger_server_*" | sed 's/^.*server_//'); do
+        stopCluster "$clusterId"
     done
     $DIR/docker/zookeeper.sh stop
 }
 
-stopCluster() {
-    $DIR/docker/waltz-server.sh stop $1
-    $DIR/docker/waltz-storage.sh stop $1
-}
-
 clean() {
-    for clusterId in $(docker container ls -a --format '{{.Names}}' --filter "name=waltz-server-*" | sed 's/^.*-//'); do
-        cleanCluster $clusterId
+    for clusterId in $(docker container ls -a --format '{{.Names}}' --filter "name=waltz_ledger_server_*" | sed 's/^.*server_//'); do
+        cleanCluster "$clusterId"
     done
     $DIR/docker/zookeeper.sh clean
 }
 
 cleanCluster() {
-    $DIR/docker/waltz-server.sh clean $1
-    $DIR/docker/waltz-storage.sh clean $1
-    rm -r $DIR/../build/config-$1
+    $DIR/docker/waltz-server.sh clean "$1"
+    $DIR/docker/waltz-storage.sh clean "$1"
+    rm -r $DIR/../build/config-"$1"
 }
 
 case $cmd in
     start)
         set -e
-        #
-        clusterId=$(docker container ls --format '{{.Names}}' --filter "name=waltz-server-*" | wc -l)
-        initNetwork
-        startCluster $clusterId
+        if [ "$#" -eq 1 ]; then
+            initNetwork
+            startCluster "$defaultClusterName"
+        else
+            initNetwork
+            for clusterName in "${@:2}"; do
+                startCluster "$clusterName"
+            done
+        fi
         ;;
     stop)
         if [ "$#" -eq 2 ]; then
@@ -77,10 +102,10 @@ case $cmd in
             stopCluster $2
             startCluster $2
         else
-            count=$(docker container ls -a --format '{{.Names}}' --filter "name=waltz-server-*" | wc -l)
             stop
-            for clusterId in $($count); do
-                startCluster $clusterId
+            initNetwork
+            for clusterName in $(docker container ls -a --format '{{.Names}}' --filter "name=waltz_ledger_server_*" | sed 's/^.*server_//'); do
+                startCluster $clusterName
             done
         fi
         ;;

--- a/bin/test-cluster.sh
+++ b/bin/test-cluster.sh
@@ -37,7 +37,7 @@ getContainerPort() {
 rerun() {
     clusterName=$1
     serverPortBase=$(getContainerPort "${clusterName}_server")
-    storePortBase=$(getContainerPort "${clusterName}_store")
+    storePortBase=$(getContainerPort "${clusterName}_storage")
     startCluster $clusterName $serverPortBase $storePortBase
 }
 
@@ -62,7 +62,7 @@ stopCluster() {
 }
 
 stop() {
-    for clusterName in $(docker container ls --format '{{.Names}}' --filter "name=waltz_.*" | sed 's/_server//; s/_store//' | uniq); do
+    for clusterName in $(docker container ls --format '{{.Names}}' --filter "name=waltz_.*" | sed 's/_server//; s/_storage//' | uniq); do
         echo $clusterName
         stopCluster "$clusterName"
     done
@@ -70,7 +70,7 @@ stop() {
 }
 
 clean() {
-    for clusterName in $(docker container ls -a --format '{{.Names}}' --filter "name=waltz_.*" | sed 's/_server//; s/_store//' | uniq); do
+    for clusterName in $(docker container ls -a --format '{{.Names}}' --filter "name=waltz_.*" | sed 's/_server//; s/_storage//' | uniq); do
         cleanCluster "$clusterName"
     done
     $DIR/docker/zookeeper.sh clean
@@ -90,7 +90,7 @@ case $cmd in
             initNetwork
             startCluster "waltz_cluster" "$defaultServerPortBase" "$defaultStoragePortBase"
         elif [ "$#" -eq 2 ]; then
-            containerExists=$(docker container ls -a --format '{{.Names}}' --filter "name=waltz_$2.*" | sed 's/_server//; s/_store//' | uniq | wc -l)
+            containerExists=$(docker container ls -a --format '{{.Names}}' --filter "name=waltz_$2.*" | sed 's/_server//; s/_storage//' | uniq | wc -l)
             if [ $containerExists -ne 1 ]; then
                 echo "Missing cluster with name waltz_$2. No attempt to start cluster again at the same port numbers."
                 exit 1
@@ -123,7 +123,7 @@ case $cmd in
         else
             stop
             initNetwork
-            for clusterName in $(docker container ls -a --format '{{.Names}}' --filter "name=waltz_.*" | sed 's/_server//; s/_store//' | uniq); do
+            for clusterName in $(docker container ls -a --format '{{.Names}}' --filter "name=waltz_.*" | sed 's/_server//; s/_storage//' | uniq); do
                 rerun "$clusterName"
             done
         fi

--- a/bin/test-cluster.sh
+++ b/bin/test-cluster.sh
@@ -2,41 +2,113 @@
 
 DIR=$(dirname $0)
 cmd=$1
+serverPortBase=55180
+storagePortBase=55280
+storagePortsOccupied=3
+serverPortsOccupied=3
 
 start() {
+    set -e
+    numWaltzClusters=$1
     $DIR/docker/create-network.sh
     $DIR/docker/zookeeper.sh start
-    $DIR/docker/cluster.sh create
-    $DIR/docker/waltz-storage.sh start
-    $DIR/docker/add-storage.sh
-    $DIR/docker/waltz-server.sh start
+    for clusterNumber in $(seq 0 $(($numWaltzClusters - 1))); do
+        initiateCluster $clusterNumber
+        echo "----- Cluster $clusterNumber created!"
+    done
+}
+
+initiateCluster() {
+    clusterNumber=$1
+    serverPortLowerBound=$((serverPortBase + $clusterNumber * $serverPortsOccupied))
+    storagePortLowerBound=$(($storagePortBase + $clusterNumber * $storagePortsOccupied))
+    $DIR/docker/cluster-config-files.sh $clusterNumber $serverPortLowerBound $storagePortLowerBound
+
+    $DIR/docker/cluster.sh create $clusterNumber
+    $DIR/docker/waltz-storage.sh start "$clusterNumber" $storagePortLowerBound $(($storagePortLowerBound + $storagePortsOccupied - 1)) 0
+    $DIR/docker/add-storage.sh $clusterNumber $storagePortLowerBound
+    $DIR/docker/waltz-server.sh start $clusterNumber $serverPortLowerBound $(($serverPortLowerBound + $serverPortsOccupied - 1))
 }
 
 stop() {
-    $DIR/docker/waltz-server.sh stop
-    $DIR/docker/waltz-storage.sh stop
+    for clusterNumber in $(docker container ls --format '{{.Names}}' --filter "name=waltz-server-*" | sed 's/^.*-//'); do
+        stopCluster $clusterNumber
+    done
     $DIR/docker/zookeeper.sh stop
 }
 
+stopCluster() {
+    $DIR/docker/waltz-server.sh stop $1
+    $DIR/docker/waltz-storage.sh stop $1
+}
+
 clean() {
-    $DIR/docker/waltz-server.sh clean
-    $DIR/docker/waltz-storage.sh clean
+    for clusterNumber in $(docker container ls -a --format '{{.Names}}' --filter "name=waltz-server-*" | sed 's/^.*-//'); do
+        cleanCluster $clusterNumber
+    done
     $DIR/docker/zookeeper.sh clean
+}
+
+cleanCluster() {
+    $DIR/docker/waltz-server.sh clean $1
+    $DIR/docker/waltz-storage.sh clean $1
+    rm -r $DIR/../build/config-$1
+}
+
+addCluster() {
+    # The total count of all clusters is also the name of the newly created cluster
+    count=$(docker container ls -a --format '{{.Names}}' --filter "name=waltz-server-*" | wc -l)
+    initiateCluster $count
+    echo "----- Cluster $count added"
 }
 
 case $cmd in
     start)
-        start
+        if [ "$#" -ne 2 ]; then
+            echo "Usage: $0 $1 Number_of_clusters_to_be_created" >&2
+            exit 1
+        fi
+        start $2
         ;;
     stop)
         stop
         ;;
     restart)
+        count=$(docker container ls -a --format '{{.Names}}' --filter "name=waltz-server-*" | wc -l)
         stop
-        start
+        start $count
         ;;
     clean)
         clean
+        ;;
+    addCluster)
+        clusterNumber=$(docker container ls --format '{{.Names}}' --filter "name=waltz-server-*" | wc -l)
+        if [ "$#" -eq 2 ]; then
+            clusterNumber=$2
+        fi
+        addCluster $2
+        ;;
+    stopCluster)
+        if [ "$#" -ne 2 ]; then
+            echo "Usage: $0 $1 Number of a cluster to be stopped" >&2
+            exit 1
+        fi
+        stopCluster $2
+        ;;
+    cleanCluster)
+        if [ "$#" -ne 2 ]; then
+            echo "Usage: $0 $1 Number of a cluster to be removed" >&2
+            exit 1
+        fi
+        cleanCluster $2
+        ;;
+    restartCluster)
+        if [ "$#" -ne 2 ]; then
+            echo "Usage: $0 $1 Cluster to be restarted" >&2
+            exit 1
+        fi
+        stopCluster $2
+        initiateCluster $2
         ;;
     *)
         echo "invalid command"


### PR DESCRIPTION
dynamic cluster management in test-cluster.sh (create, add, restart, stop, clean)

Before testing for the first time remove zk, waltz storage and waltz server docker images

try:
./bin/test-cluster.sh start 3                  #creates 3 clusters, each consists of one server and storage node
./bin/test-cluster.sh restartCluster 1   #restarts cluster 1
./bin/test-cluster.sh stopCluster 0      #stops cluster 0
./bin/test-cluster.sh addCluster.          #adds new cluster (will be named as cluster 3)
./bin/test-cluster.sh stop                      #stops all running waltz clusters
./bin/test-cluster.sh clean                    #removes all waltz clusters
