### PR TITLE
Add getters for PartitionLocalLock class

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/PartitionLocalLock.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/PartitionLocalLock.java
@@ -46,4 +46,11 @@ public class PartitionLocalLock {
         }
     }
 
+    public String getName() {
+        return name;
+    }
+
+    public long getId() {
+        return id;
+    }
 }


### PR DESCRIPTION
This PR simply adds getters for PartitionLocalLock class. It may be useful for Waltz clients that may want to use directly that class to maintain their object locks for concurrency control.