### PR TITLE
Re-Formatting Cli calls to be more Acme reporting friendly.

### DIFF
--- a/waltz-common/src/main/java/com/wepay/waltz/common/util/SubcommandCli.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/util/SubcommandCli.java
@@ -62,8 +62,8 @@ public class SubcommandCli {
                 logger.info(String.format("Successfully executed %s:%s command!", getClass().getName(),
                     subcommand.name));
             } catch (SubCommandFailedException e) {
-                logger.info(String.format("Failed to execute %s:%s command, error: %s", getClass().getName(),
-                    subcommand.name, e.getMessage()));
+                logger.info(String.format("Failed to execute %s:%s command, error: %s%n", getClass().getName(),
+                    subcommand.name, e.getMessage().replace("\n", "\n  ")));
                 cli.printError(e.getMessage());
                 if (!useByTest) {
                     System.exit(1);

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
@@ -315,7 +315,10 @@ public final class ClusterCli extends SubcommandCli {
 
                 if (loggerAsOutput) {
                     Logger logger = Logging.getLogger(Verify.class);
-                    logger.info(OUTPUT_BUILDER.toString());
+                    String[] splitParagraphs = OUTPUT_BUILDER.toString().split("\n(?=[^ ])");
+                    for (String paragraph : splitParagraphs) {
+                        logger.info(paragraph);
+                    }
                 } else {
                     System.out.println(OUTPUT_BUILDER);
                 }
@@ -633,7 +636,7 @@ public final class ClusterCli extends SubcommandCli {
             ValidationResult validationResult = partitionResult.validationResultsMap.get(type);
             if (validationResult.status.equals(ValidationResult.Status.FAILURE)) {
                 OUTPUT_BUILDER.append(String.format("Validation %s failed for partition %s%n", type.name(), partitionId));
-                OUTPUT_BUILDER.append(String.format("Validation error is: %s%n", validationResult.error));
+                OUTPUT_BUILDER.append(String.format("  Validation error is: %s%n", validationResult.error.replace("\n", "\n  ")));
                 return false;
             }
             return true;

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
@@ -315,7 +315,7 @@ public final class ClusterCli extends SubcommandCli {
 
                 if (loggerAsOutput) {
                     Logger logger = Logging.getLogger(Verify.class);
-                    String[] splitParagraphs = OUTPUT_BUILDER.toString().split("\n(?=[^ ])");
+                    String[] splitParagraphs = OUTPUT_BUILDER.toString().split("\n(?=[^\\s])");
                     for (String paragraph : splitParagraphs) {
                         logger.info(paragraph);
                     }

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/server/ServerCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/server/ServerCli.java
@@ -150,7 +150,7 @@ public final class ServerCli extends SubcommandCli {
             }
             if (loggerAsOutput) {
                 Logger logger = Logging.getLogger(ListPartition.class);
-                String[] splitParagraphs = sb.toString().split("\n(?=[^ ])");
+                String[] splitParagraphs = sb.toString().split("\n(?=[^\\s])");
                 for (String paragraph : splitParagraphs) {
                     logger.info(paragraph);
                 }

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/server/ServerCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/server/ServerCli.java
@@ -140,7 +140,7 @@ public final class ServerCli extends SubcommandCli {
         private void printResult(Integer numPartitions, Map<Integer, List<String>> replicaInfo, boolean loggerAsOutput) {
             // display partition info
             StringBuilder sb = new StringBuilder();
-            sb.append(String.format("%nThere are %d partitions for current server%n", numPartitions));
+            sb.append(String.format("There are %d partitions for current server%n", numPartitions));
 
             // display replica info
             for (Map.Entry<Integer, List<String>> entry: replicaInfo.entrySet()) {
@@ -150,7 +150,10 @@ public final class ServerCli extends SubcommandCli {
             }
             if (loggerAsOutput) {
                 Logger logger = Logging.getLogger(ListPartition.class);
-                logger.info(sb.toString());
+                String[] splitParagraphs = sb.toString().split("\n(?=[^ ])");
+                for (String paragraph : splitParagraphs) {
+                    logger.info(paragraph);
+                }
             } else {
                 System.out.println(sb);
             }

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
@@ -142,7 +142,7 @@ public final class StorageCli extends SubcommandCli {
             }
             if (loggerAsOutput) {
                 Logger logger = Logging.getLogger(ListPartition.class);
-                String[] splitParagraphs = OUTPUT_BUILDER.toString().split("\n(?=[^ ])");
+                String[] splitParagraphs = OUTPUT_BUILDER.toString().split("\n(?=[^\\s])");
                 for (String paragraph : splitParagraphs) {
                     logger.info(paragraph);
                 }

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
@@ -155,7 +155,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                 }
                 if (loggerAsOutput) {
                     Logger logger = Logging.getLogger(ListZk.class);
-                    String[] splitParagraphs = OUTPUT_BUILDER.toString().split("\n(?=[^ ])");
+                    String[] splitParagraphs = OUTPUT_BUILDER.toString().split("\n(?=[^\\s])");
                     for (String paragraph : splitParagraphs) {
                         logger.info(paragraph);
                     }
@@ -172,7 +172,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                 OUTPUT_BUILDER.append(String.format("  key=%s%n", storeParams.key.toString()));
                 OUTPUT_BUILDER.append(String.format("  numPartitions=%s%n", storeParams.numPartitions));
             } else {
-                OUTPUT_BUILDER.append(String.format("Store parameters not found%n"));
+                OUTPUT_BUILDER.append(String.format("  Store parameters not found%n"));
             }
         }
 
@@ -186,7 +186,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                     OUTPUT_BUILDER.append(String.format("  %s = %s, GroupId: %s%n", entry.getKey(), Arrays.toString(entry.getValue()), groups.get(entry.getKey())));
                 }
             } else {
-                OUTPUT_BUILDER.append(String.format("Replicas not found%n"));
+                OUTPUT_BUILDER.append(String.format("  Replicas not found%n"));
             }
         }
 
@@ -199,7 +199,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                     OUTPUT_BUILDER.append(String.format("  %s has admin port: %s%n", entry.getKey(), entry.getValue()));
                 }
             } else {
-                OUTPUT_BUILDER.append(String.format("Connections not found%n"));
+                OUTPUT_BUILDER.append(String.format("  Connections not found%n"));
             }
         }
 
@@ -217,7 +217,7 @@ public final class ZooKeeperCli extends SubcommandCli {
                         entry.getKey(), entry.getValue().sessionId, ((entry.getValue().closingHighWaterMark) == ReplicaState.UNRESOLVED ? "UNRESOLVED" : entry.getValue().closingHighWaterMark)));
                 }
             } else {
-                OUTPUT_BUILDER.append(String.format("No node found%n"));
+                OUTPUT_BUILDER.append(String.format("  No node found%n"));
             }
         }
 

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
@@ -155,7 +155,10 @@ public final class ZooKeeperCli extends SubcommandCli {
                 }
                 if (loggerAsOutput) {
                     Logger logger = Logging.getLogger(ListZk.class);
-                    logger.info(OUTPUT_BUILDER.toString());
+                    String[] splitParagraphs = OUTPUT_BUILDER.toString().split("\n(?=[^ ])");
+                    for (String paragraph : splitParagraphs) {
+                        logger.info(paragraph);
+                    }
                 } else {
                     System.out.println(OUTPUT_BUILDER);
                 }

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/zk/ZooKeeperCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/zk/ZooKeeperCliTest.java
@@ -176,9 +176,9 @@ public final class ZooKeeperCliTest {
                     + "  ReplicaId(0,fakehost0:6000), SessionId: -1, closingHighWaterMark: UNRESOLVED\n"
                     + "  ReplicaId(0,fakehost1:6001), SessionId: -1, closingHighWaterMark: UNRESOLVED\n"
                     + "store [/test/root/store/partition/1] replica states:\n"
-                    + "No node found\n"
+                    + "  No node found\n"
                     + "store [/test/root/store/partition/2] replica states:\n"
-                    + "No node found\n";
+                    + "  No node found\n";
 
             assertTrue(outContent.toString("UTF-8").contains(expectedCmdOutput));
 


### PR DESCRIPTION
- For Cli calls with logger-as-output option, the whole string reply is split into individual paragraphs (split only where \n is followed by non-space character). This is important because otherwise only first paragraph includes labels like appService.threadName or appService.javaClass in Acme.
- SubcommandCli offsets error message with two spaces to be included in Acme as a single message