### PR TITLE
Update WaltzClient’s Partition metrics

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalBaseClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalBaseClient.java
@@ -261,14 +261,12 @@ public abstract class InternalBaseClient implements WaltzNetworkClientCallbacks,
         }
 
         this.numPartitions = numPartitions;
-        String connectionType;
         for (int partitionId = 0; partitionId < numPartitions; partitionId++) {
-            if (this instanceof RpcClient) {
-                connectionType = ClientConnectionType.RPC.toString().toLowerCase();
-            } else {
-                connectionType = ClientConnectionType.STREAM.toString().toLowerCase();
-            }
-            Partition partition = new Partition(partitionId, clientId, maxConcurrentTransactions, connectionType);
+            String clientConnectionType = (this instanceof RpcClient) ?
+                ClientConnectionType.RPC.toString().toLowerCase() :
+                ClientConnectionType.STREAM.toString().toLowerCase();
+
+            Partition partition = new Partition(partitionId, clientId, maxConcurrentTransactions, clientConnectionType);
             partitions.put(partitionId, partition);
         }
 

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalBaseClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalBaseClient.java
@@ -36,6 +36,9 @@ import java.util.concurrent.TimeUnit;
 public abstract class InternalBaseClient implements WaltzNetworkClientCallbacks, ManagedClient {
 
     private static final Logger logger = Logging.getLogger(InternalBaseClient.class);
+    private enum ClientConnectionType {
+        RPC, STREAM
+    }
 
     private int clientId = -1;
     private String clusterName = null;
@@ -258,9 +261,14 @@ public abstract class InternalBaseClient implements WaltzNetworkClientCallbacks,
         }
 
         this.numPartitions = numPartitions;
-
+        String connectionType;
         for (int partitionId = 0; partitionId < numPartitions; partitionId++) {
-            Partition partition = new Partition(partitionId, clientId, maxConcurrentTransactions);
+            if (this instanceof RpcClient) {
+                connectionType = ClientConnectionType.RPC.toString().toLowerCase();
+            } else {
+                connectionType = ClientConnectionType.STREAM.toString().toLowerCase();
+            }
+            Partition partition = new Partition(partitionId, clientId, maxConcurrentTransactions, connectionType);
             partitions.put(partitionId, partition);
         }
 

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalBaseClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalBaseClient.java
@@ -36,9 +36,8 @@ import java.util.concurrent.TimeUnit;
 public abstract class InternalBaseClient implements WaltzNetworkClientCallbacks, ManagedClient {
 
     private static final Logger logger = Logging.getLogger(InternalBaseClient.class);
-    private enum ClientConnectionType {
-        RPC, STREAM
-    }
+    private static final String CLIENT_CONNECTION_TYPE_RPC = "rpc";
+    private static final String CLIENT_CONNECTION_TYPE_STREAM = "stream";
 
     private int clientId = -1;
     private String clusterName = null;
@@ -262,9 +261,8 @@ public abstract class InternalBaseClient implements WaltzNetworkClientCallbacks,
 
         this.numPartitions = numPartitions;
         for (int partitionId = 0; partitionId < numPartitions; partitionId++) {
-            String clientConnectionType = (this instanceof RpcClient) ?
-                ClientConnectionType.RPC.toString().toLowerCase() :
-                ClientConnectionType.STREAM.toString().toLowerCase();
+            String clientConnectionType = (this instanceof RpcClient)
+                ? CLIENT_CONNECTION_TYPE_RPC : CLIENT_CONNECTION_TYPE_STREAM;
 
             Partition partition = new Partition(partitionId, clientId, maxConcurrentTransactions, clientConnectionType);
             partitions.put(partitionId, partition);

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/Partition.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/Partition.java
@@ -79,9 +79,9 @@ public class Partition {
      * @param partitionId the partition id.
      * @param clientId the client id.
      * @param maxConcurrentTransactions the maximum concurrent transactions that can be submitted to this partition.
-     * @param connectionType the type of client connection i.e. rpc or stream.
+     * @param clientConnectionType the type of client connection i.e. rpc or stream.
      */
-    public Partition(int partitionId, int clientId, int maxConcurrentTransactions, String connectionType) {
+    public Partition(int partitionId, int clientId, int maxConcurrentTransactions, String clientConnectionType) {
         this.partitionId = partitionId;
         this.clientId = clientId;
         this.generation = -1;
@@ -91,7 +91,7 @@ public class Partition {
         this.clientHighWaterMark = new AtomicLong(-1);
         this.dataFutures = new HashMap<>();
         this.metricGroup = String.format("%s-%s.partition-%d", MetricGroup.WALTZ_CLIENT_METRIC_GROUP,
-            connectionType, partitionId);
+            clientConnectionType, partitionId);
         registerMetrics();
     }
 

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/Partition.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/Partition.java
@@ -79,8 +79,9 @@ public class Partition {
      * @param partitionId the partition id.
      * @param clientId the client id.
      * @param maxConcurrentTransactions the maximum concurrent transactions that can be submitted to this partition.
+     * @param connectionType the type of client connection i.e. rpc or stream.
      */
-    public Partition(int partitionId, int clientId, int maxConcurrentTransactions) {
+    public Partition(int partitionId, int clientId, int maxConcurrentTransactions, String connectionType) {
         this.partitionId = partitionId;
         this.clientId = clientId;
         this.generation = -1;
@@ -89,8 +90,8 @@ public class Partition {
         this.networkClient = null;
         this.clientHighWaterMark = new AtomicLong(-1);
         this.dataFutures = new HashMap<>();
-        this.metricGroup = String.format("%s.partition-%d", MetricGroup.WALTZ_CLIENT_METRIC_GROUP, partitionId);
-
+        this.metricGroup = String.format("%s-%s.partition-%d", MetricGroup.WALTZ_CLIENT_METRIC_GROUP,
+            connectionType, partitionId);
         registerMetrics();
     }
 
@@ -738,6 +739,7 @@ public class Partition {
 
     private void registerMetrics() {
         REGISTRY.gauge(metricGroup, "is-mounted", (Gauge<Boolean>) () -> isMounted());
+        REGISTRY.gauge(metricGroup, "is-partition-active", (Gauge<Boolean>) () -> isActive());
         REGISTRY.gauge(metricGroup, "high-water-mark", (Gauge<Long>) () -> clientHighWaterMark());
         REGISTRY.gauge(metricGroup, "num-registered-transactions",
             (Gauge<Integer>) transactionMonitor::registeredCount);
@@ -752,6 +754,7 @@ public class Partition {
 
     private void unregisterMetrics() {
         REGISTRY.remove(metricGroup, "is-mounted");
+        REGISTRY.remove(metricGroup, "is-partition-active");
         REGISTRY.remove(metricGroup, "high-water-mark");
         REGISTRY.remove(metricGroup, "num-registered-transactions");
         REGISTRY.remove(metricGroup, "lock-failure");


### PR DESCRIPTION
_**1. Update MetricGroup**_
This is to isolate as well as differentiate the metrics emitted via the rpcClient and the streamClient. 

As both rpcClient and streamClient create a separate Partition object (for a given partition Id), using the same metricGroup name (for the Partition object) was causing an issue. This is because the metrics will not be created if the same metricGroup and metricName is used again.

Based on the code change, the metric of the WaltzClient's Partition object (for partitionId=0) will be emitted as:
- waltz-client-rpc.partition-0 
- waltz-client-stream.partition-0

_**2. Create a new metric for `is-partition-active`**_ 