### PR TITLE
Cli StringBuilder output fix

### DIFF
--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
@@ -322,7 +322,6 @@ public final class ClusterCli extends SubcommandCli {
                 } else {
                     System.out.println(outputBuilder);
                 }
-                outputBuilder.setLength(0);
             }
         }
 

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
@@ -163,9 +163,9 @@ public final class ClusterCli extends SubcommandCli {
     private static final class Verify extends Cli {
         private static final String NAME = "verify";
         private static final String DESCRIPTION = "Validates if partition(s) is handled by some server";
-        private static final StringBuilder OUTPUT_BUILDER = new StringBuilder();
 
         private final PartitionAssignmentPolicy partitionAssignmentPolicy = new DynamicPartitionAssignmentPolicy();
+        private final StringBuilder outputBuilder = new StringBuilder();
 
         private long timeoutInSeconds = 10;
 
@@ -315,14 +315,14 @@ public final class ClusterCli extends SubcommandCli {
 
                 if (loggerAsOutput) {
                     Logger logger = Logging.getLogger(Verify.class);
-                    String[] splitParagraphs = OUTPUT_BUILDER.toString().split("\n(?=[^\\s])");
+                    String[] splitParagraphs = outputBuilder.toString().split("\n(?=[^\\s])");
                     for (String paragraph : splitParagraphs) {
                         logger.info(paragraph);
                     }
                 } else {
-                    System.out.println(OUTPUT_BUILDER);
+                    System.out.println(outputBuilder);
                 }
-                OUTPUT_BUILDER.setLength(0);
+                outputBuilder.setLength(0);
             }
         }
 
@@ -635,8 +635,8 @@ public final class ClusterCli extends SubcommandCli {
 
             ValidationResult validationResult = partitionResult.validationResultsMap.get(type);
             if (validationResult.status.equals(ValidationResult.Status.FAILURE)) {
-                OUTPUT_BUILDER.append(String.format("Validation %s failed for partition %s%n", type.name(), partitionId));
-                OUTPUT_BUILDER.append(String.format("  Validation error is: %s%n", validationResult.error.replace("\n", "\n  ")));
+                outputBuilder.append(String.format("Validation %s failed for partition %s%n", type.name(), partitionId));
+                outputBuilder.append(String.format("  Validation error is: %s%n", validationResult.error.replace("\n", "\n  ")));
                 return false;
             }
             return true;

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
@@ -68,10 +68,10 @@ public final class StorageCli extends SubcommandCli {
     private static final class ListPartition extends Cli {
         private static final String NAME = "list";
         private static final String DESCRIPTION = "List partition ownership data of a storage node";
-        private static final StringBuilder OUTPUT_BUILDER = new StringBuilder();
 
         private static final String STORAGE_PARTITION_METRIC_KEY = "waltz-storage.waltz-storage-partition-ids";
         private final ObjectMapper mapper = new ObjectMapper();
+        private final StringBuilder outputBuilder = new StringBuilder();
 
         protected ListPartition(String[] args) {
             super(args);
@@ -133,8 +133,8 @@ public final class StorageCli extends SubcommandCli {
 
                     String metricsJson = getMetricsJson(storageHost, Integer.parseInt(storagePort), cliConfigPath);
                     Map<Integer, PartitionInfoSnapshot> partitionInfo = getPartitionInfo(metricsJson);
-                    OUTPUT_BUILDER.append(formatPartitionInfo(partitionInfo, storageHost, storagePort));
-                    OUTPUT_BUILDER.append(System.lineSeparator());
+                    outputBuilder.append(formatPartitionInfo(partitionInfo, storageHost, storagePort));
+                    outputBuilder.append(System.lineSeparator());
                 } catch (Exception e) {
                     throw new SubCommandFailedException(String.format("Cannot fetch partition ownership for %s:%s:%n%s",
                             hostAndPortArray[0], hostAndPortArray[1], e.getMessage()));
@@ -142,13 +142,14 @@ public final class StorageCli extends SubcommandCli {
             }
             if (loggerAsOutput) {
                 Logger logger = Logging.getLogger(ListPartition.class);
-                String[] splitParagraphs = OUTPUT_BUILDER.toString().split("\n(?=[^\\s])");
+                String[] splitParagraphs = outputBuilder.toString().split("\n(?=[^\\s])");
                 for (String paragraph : splitParagraphs) {
                     logger.info(paragraph);
                 }
             } else {
-                System.out.println(OUTPUT_BUILDER);
+                System.out.println(outputBuilder);
             }
+            outputBuilder.setLength(0);
         }
 
         private List<String[]> getAllHostsAndPorts(String cliConfigPath) throws Exception {

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/storage/StorageCli.java
@@ -149,7 +149,6 @@ public final class StorageCli extends SubcommandCli {
             } else {
                 System.out.println(outputBuilder);
             }
-            outputBuilder.setLength(0);
         }
 
         private List<String[]> getAllHostsAndPorts(String cliConfigPath) throws Exception {

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
@@ -163,7 +163,6 @@ public final class ZooKeeperCli extends SubcommandCli {
                 } else {
                     System.out.println(outputBuilder);
                 }
-                outputBuilder.setLength(0);
             }
         }
 

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/zk/ZooKeeperCli.java
@@ -83,7 +83,8 @@ public final class ZooKeeperCli extends SubcommandCli {
     private static final class ListZk extends Cli {
         private static final String NAME = "list";
         private static final String DESCRIPTION = "Displays server metadata.";
-        private static final StringBuilder OUTPUT_BUILDER = new StringBuilder();
+
+        private final StringBuilder outputBuilder = new StringBuilder();
 
         protected ListZk(String[] args) {
             super(args);
@@ -155,69 +156,70 @@ public final class ZooKeeperCli extends SubcommandCli {
                 }
                 if (loggerAsOutput) {
                     Logger logger = Logging.getLogger(ListZk.class);
-                    String[] splitParagraphs = OUTPUT_BUILDER.toString().split("\n(?=[^\\s])");
+                    String[] splitParagraphs = outputBuilder.toString().split("\n(?=[^\\s])");
                     for (String paragraph : splitParagraphs) {
                         logger.info(paragraph);
                     }
                 } else {
-                    System.out.println(OUTPUT_BUILDER);
+                    System.out.println(outputBuilder);
                 }
+                outputBuilder.setLength(0);
             }
         }
 
         private void listStoreParams(ZNode storeRoot, StoreParams storeParams) {
-            OUTPUT_BUILDER.append(String.format("store [%s] parameters:%n", storeRoot));
+            outputBuilder.append(String.format("store [%s] parameters:%n", storeRoot));
 
             if (storeParams != null) {
-                OUTPUT_BUILDER.append(String.format("  key=%s%n", storeParams.key.toString()));
-                OUTPUT_BUILDER.append(String.format("  numPartitions=%s%n", storeParams.numPartitions));
+                outputBuilder.append(String.format("  key=%s%n", storeParams.key.toString()));
+                outputBuilder.append(String.format("  numPartitions=%s%n", storeParams.numPartitions));
             } else {
-                OUTPUT_BUILDER.append(String.format("  Store parameters not found%n"));
+                outputBuilder.append(String.format("  Store parameters not found%n"));
             }
         }
 
         private void listReplicaAndGroupAssignments(ZNode storeRoot, ReplicaAssignments replicaAssignments, GroupDescriptor groupDescriptor) throws Exception {
-            OUTPUT_BUILDER.append(String.format("store [%s] replica and group assignments:%n", storeRoot));
+            outputBuilder.append(String.format("store [%s] replica and group assignments:%n", storeRoot));
 
             if ((replicaAssignments != null) && (groupDescriptor != null)) {
                 Map<String, int[]> replicas = new TreeMap<>(replicaAssignments.replicas);
                 Map<String, Integer> groups = groupDescriptor.groups;
                 for (Map.Entry<String, int[]> entry : replicas.entrySet()) {
-                    OUTPUT_BUILDER.append(String.format("  %s = %s, GroupId: %s%n", entry.getKey(), Arrays.toString(entry.getValue()), groups.get(entry.getKey())));
+                    outputBuilder.append(String.format("  %s = %s, GroupId: %s%n", entry.getKey(), Arrays.toString(entry.getValue()), groups.get(entry.getKey())));
                 }
             } else {
-                OUTPUT_BUILDER.append(String.format("  Replicas not found%n"));
+                outputBuilder.append(String.format("  Replicas not found%n"));
             }
         }
 
         private void listConnections(ZNode storeRoot, ConnectionMetadata connectionMetadata) {
-            OUTPUT_BUILDER.append(String.format("store [%s] connections:%n", storeRoot));
+            outputBuilder.append(String.format("store [%s] connections:%n", storeRoot));
 
             if ((connectionMetadata != null)) {
                 Map<String, Integer> connections = connectionMetadata.connections;
                 for (Map.Entry<String, Integer> entry : connections.entrySet()) {
-                    OUTPUT_BUILDER.append(String.format("  %s has admin port: %s%n", entry.getKey(), entry.getValue()));
+                    outputBuilder.append(String.format("  %s has admin port: %s%n", entry.getKey(), entry.getValue()));
                 }
             } else {
-                OUTPUT_BUILDER.append(String.format("  Connections not found%n"));
+                outputBuilder.append(String.format("  Connections not found%n"));
             }
         }
 
         private void listClusterInfoAndServerPartitionAssignments(ZooKeeperClient zkClient, ZNode root) throws Exception {
-            OUTPUT_BUILDER.append(ListCluster.list(root, zkClient));
+            outputBuilder.append(ListCluster.list(root, zkClient));
         }
 
         private void listReplicaState(ZNode znode, Map<ReplicaId, ReplicaState> replicaState) {
-            OUTPUT_BUILDER.append(String.format("store [%s] replica states:%n", znode));
+            outputBuilder.append(String.format("store [%s] replica states:%n", znode));
 
             if (replicaState.size() > 0) {
                 Map<ReplicaId, ReplicaState> sortedReplicaState = new TreeMap<>(replicaState);
                 for (Map.Entry<ReplicaId, ReplicaState> entry : sortedReplicaState.entrySet()) {
-                    OUTPUT_BUILDER.append(String.format("  %s, SessionId: %s, closingHighWaterMark: %s%n",
+                    outputBuilder.append(String.format("  %s, SessionId: %s, closingHighWaterMark: %s%n",
                         entry.getKey(), entry.getValue().sessionId, ((entry.getValue().closingHighWaterMark) == ReplicaState.UNRESOLVED ? "UNRESOLVED" : entry.getValue().closingHighWaterMark)));
                 }
             } else {
-                OUTPUT_BUILDER.append(String.format("  No node found%n"));
+                outputBuilder.append(String.format("  No node found%n"));
             }
         }
 


### PR DESCRIPTION
Made SB of Cli calls non static, added SB.setLength(0) where missing - already been in ClusterCli

This fixes the undesired behavior of seeing old Cli messages during current Cli execution. Because of a logger drop rate this results in uninterpretable logs which are a mix of everything. What happens: SB appends new messages to old messages that are kept in SB object and prints all of them.