### PR TITLE
Fix to populate current high-water-mark of a partition to commitHighWaterMark variable in AppendTask.init()

### DIFF
--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
@@ -101,6 +101,7 @@ public class Partition {
         this.catchupFeedTask = new FeedTask("C", new LinkedBlockingQueue<>());
         this.pausedFeedContexts = new LinkedList<>();
         this.metricsGroup = String.format("%s.partition-%d", MetricGroup.WALTZ_SERVER_METRIC_GROUP, partitionId);
+
         // Register metrics
         registerMetrics();
 

--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
@@ -336,14 +336,7 @@ public class Partition {
         REGISTRY.gauge(metricsGroup, "total-real-time-feed-context-removed", (Gauge<Long>) () -> getTotalRealtimeFeedContextRemoved());
         REGISTRY.gauge(metricsGroup, "total-catchup-feed-context-added", (Gauge<Integer>) () -> getTotalCatchupFeedContextAdded());
         REGISTRY.gauge(metricsGroup, "total-catchup-feed-context-removed", (Gauge<Integer>) () -> getTotalCatchupFeedContextRemoved());
-        REGISTRY.gauge(metricsGroup, "high-water-mark", (Gauge<Long>) () -> {
-            try {
-                return storePartition.highWaterMark();
-            } catch (Exception e) {
-                logger.info("Failed to fetch highWaterMark for partition " + partitionId + ".");
-                return Long.MIN_VALUE;
-            }
-        });
+        REGISTRY.gauge(metricsGroup, "high-water-mark", (Gauge<Long>) () -> commitHighWaterMark);
     }
 
     private void unregisterMetrics() {
@@ -528,7 +521,8 @@ public class Partition {
 
         @Override
         public void init() throws Exception {
-            locks = new Locks(lockTableSize, 3, storePartition.highWaterMark());
+            commitHighWaterMark = storePartition.highWaterMark();
+            locks = new Locks(lockTableSize, 3, commitHighWaterMark);
         }
 
         @Override

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/server/ServerCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/server/ServerCliTest.java
@@ -4,6 +4,7 @@ import com.wepay.waltz.test.util.IntegrationTestHelper;
 import com.wepay.waltz.test.util.SeparateClassLoaderJUnitRunner;
 import com.wepay.waltz.test.util.SslSetup;
 import com.wepay.waltz.test.util.WaltzServerRunner;
+import com.wepay.waltz.test.util.WaltzStorageRunner;
 import com.wepay.waltz.tools.CliConfig;
 import com.wepay.zktools.clustermgr.PartitionInfo;
 import com.wepay.zktools.clustermgr.internal.PartitionAssignment;
@@ -63,16 +64,26 @@ public final class ServerCliTest {
 
     @Test
     public void testListPartition() throws Exception {
+        int numStorages = 3;
         Properties properties =  new Properties();
         properties.setProperty(IntegrationTestHelper.Config.ZNODE_PATH, "/server/cli/test");
         properties.setProperty(IntegrationTestHelper.Config.NUM_PARTITIONS, "3");
         properties.setProperty(IntegrationTestHelper.Config.ZK_SESSION_TIMEOUT, "30000");
+        properties.setProperty(IntegrationTestHelper.Config.NUM_STORAGES, String.valueOf(numStorages));
 
         IntegrationTestHelper helper = new IntegrationTestHelper(properties);
         int jettyPort = helper.getServerJettyPort();
 
         try {
             helper.startZooKeeperServer();
+
+            for (int s = 0; s < numStorages; s++) {
+                WaltzStorageRunner storageRunner = helper.getWaltzStorageRunner(s);
+                storageRunner.startAsync();
+                storageRunner.awaitStart();
+                helper.setWaltzStorageAssignmentWithIndex(s, true);
+            }
+
             helper.startWaltzServer(true);
 
             String[] args = {
@@ -92,11 +103,13 @@ public final class ServerCliTest {
     public void testAddAndRemovePreferredPartition() throws Exception {
         int numPartitions = 8;
         int numServers = 2;
+        int numStorages = 3;
         Properties properties =  new Properties();
         properties.setProperty(IntegrationTestHelper.Config.ZNODE_PATH, "/server/cli/test");
         properties.setProperty(IntegrationTestHelper.Config.NUM_PARTITIONS, String.valueOf(numPartitions));
         properties.setProperty(IntegrationTestHelper.Config.NUM_SERVERS, String.valueOf(numServers));
         properties.setProperty(IntegrationTestHelper.Config.ZK_SESSION_TIMEOUT, "30000");
+        properties.setProperty(IntegrationTestHelper.Config.NUM_STORAGES, String.valueOf(numStorages));
 
         IntegrationTestHelper helper = new IntegrationTestHelper(properties);
         Properties cfgProperties = createProperties(helper.getZkConnectString(), helper.getZnodePath(), helper.getSslSetup());
@@ -108,6 +121,13 @@ public final class ServerCliTest {
         PartitionAssignment partitionAssignment = null;
         try {
             helper.startZooKeeperServer();
+
+            for (int s = 0; s < numStorages; s++) {
+                WaltzStorageRunner storageRunner = helper.getWaltzStorageRunner(s);
+                storageRunner.startAsync();
+                storageRunner.awaitStart();
+                helper.setWaltzStorageAssignmentWithIndex(s, true);
+            }
 
             // Start Server 1
             WaltzServerRunner serverRunner1 = helper.getWaltzServerRunner(0);

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/server/ServerCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/server/ServerCliTest.java
@@ -64,25 +64,17 @@ public final class ServerCliTest {
 
     @Test
     public void testListPartition() throws Exception {
-        int numStorages = 3;
+//        int numStorages = 3;
         Properties properties =  new Properties();
         properties.setProperty(IntegrationTestHelper.Config.ZNODE_PATH, "/server/cli/test");
         properties.setProperty(IntegrationTestHelper.Config.NUM_PARTITIONS, "3");
         properties.setProperty(IntegrationTestHelper.Config.ZK_SESSION_TIMEOUT, "30000");
-        properties.setProperty(IntegrationTestHelper.Config.NUM_STORAGES, String.valueOf(numStorages));
 
         IntegrationTestHelper helper = new IntegrationTestHelper(properties);
         int jettyPort = helper.getServerJettyPort();
 
         try {
             helper.startZooKeeperServer();
-
-            for (int s = 0; s < numStorages; s++) {
-                WaltzStorageRunner storageRunner = helper.getWaltzStorageRunner(s);
-                storageRunner.startAsync();
-                storageRunner.awaitStart();
-                helper.setWaltzStorageAssignmentWithIndex(s, true);
-            }
 
             helper.startWaltzServer(true);
 
@@ -103,13 +95,11 @@ public final class ServerCliTest {
     public void testAddAndRemovePreferredPartition() throws Exception {
         int numPartitions = 8;
         int numServers = 2;
-        int numStorages = 3;
         Properties properties =  new Properties();
         properties.setProperty(IntegrationTestHelper.Config.ZNODE_PATH, "/server/cli/test");
         properties.setProperty(IntegrationTestHelper.Config.NUM_PARTITIONS, String.valueOf(numPartitions));
         properties.setProperty(IntegrationTestHelper.Config.NUM_SERVERS, String.valueOf(numServers));
         properties.setProperty(IntegrationTestHelper.Config.ZK_SESSION_TIMEOUT, "30000");
-        properties.setProperty(IntegrationTestHelper.Config.NUM_STORAGES, String.valueOf(numStorages));
 
         IntegrationTestHelper helper = new IntegrationTestHelper(properties);
         Properties cfgProperties = createProperties(helper.getZkConnectString(), helper.getZnodePath(), helper.getSslSetup());
@@ -121,13 +111,6 @@ public final class ServerCliTest {
         PartitionAssignment partitionAssignment = null;
         try {
             helper.startZooKeeperServer();
-
-            for (int s = 0; s < numStorages; s++) {
-                WaltzStorageRunner storageRunner = helper.getWaltzStorageRunner(s);
-                storageRunner.startAsync();
-                storageRunner.awaitStart();
-                helper.setWaltzStorageAssignmentWithIndex(s, true);
-            }
 
             // Start Server 1
             WaltzServerRunner serverRunner1 = helper.getWaltzServerRunner(0);

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/server/ServerCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/server/ServerCliTest.java
@@ -4,7 +4,6 @@ import com.wepay.waltz.test.util.IntegrationTestHelper;
 import com.wepay.waltz.test.util.SeparateClassLoaderJUnitRunner;
 import com.wepay.waltz.test.util.SslSetup;
 import com.wepay.waltz.test.util.WaltzServerRunner;
-import com.wepay.waltz.test.util.WaltzStorageRunner;
 import com.wepay.waltz.tools.CliConfig;
 import com.wepay.zktools.clustermgr.PartitionInfo;
 import com.wepay.zktools.clustermgr.internal.PartitionAssignment;
@@ -64,7 +63,6 @@ public final class ServerCliTest {
 
     @Test
     public void testListPartition() throws Exception {
-//        int numStorages = 3;
         Properties properties =  new Properties();
         properties.setProperty(IntegrationTestHelper.Config.ZNODE_PATH, "/server/cli/test");
         properties.setProperty(IntegrationTestHelper.Config.NUM_PARTITIONS, "3");
@@ -75,7 +73,6 @@ public final class ServerCliTest {
 
         try {
             helper.startZooKeeperServer();
-
             helper.startWaltzServer(true);
 
             String[] args = {


### PR DESCRIPTION
Currently, the high-water-mark metric in waltz-server/../Partition.java returns the value of "commitHighWaterMark" which is set to Long.MIN_VALUE when the Partition object is created. And, this variable is updated to reflect the latest high-water-mark of a partition only when there is a write to it.

Because of which when a new WaltzServer is created or existing WaltzServer is restarted or when partitions are reassigned to a different server, the high-water-mark metric displays the value as Long.MIN_VALUE for partitions which had data written to it earlier. This ticket will help in resolving that issue and populate the latest high-water-mark of a partition even after the WaltzServer restart. 
