### PR TITLE
Added multi-partition support for StorageCli

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ project.ext {
     assertjVersion = '3.8.0'
     zkToolsVersion = '0.7.3'
     yamlVersion = '1.20'
-    riffVersion = '2.4.6'
+    riffVersion = '2.5.0'
     jacksonVersion = '2.9.6'
     jettyVersion = '9.4.12.v20180830'
     mainClass = 'Main'

--- a/waltz-demo/src/main/java/com/wepay/waltz/demo/DemoServers.java
+++ b/waltz-demo/src/main/java/com/wepay/waltz/demo/DemoServers.java
@@ -22,8 +22,11 @@ import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.wepay.waltz.demo.DemoConst.WALTZ_REPLICA1_ADMIN_PORT;
 
@@ -113,9 +116,10 @@ public final class DemoServers extends DemoAppBase {
 
             StorageAdminClient storageAdminClient = new StorageAdminClient(host, port + 1, ClientSSL.createInsecureContext(), storeParams.key, storeParams.numPartitions);
             storageAdminClient.open();
-            for (int partitionId = 0; partitionId < storeParams.numPartitions; partitionId++) {
-                storageAdminClient.setPartitionAssignment(partitionId, true, false);
-            }
+
+            List<Integer> partitionIds = IntStream.range(0, storeParams.numPartitions).boxed().collect(Collectors.toList());
+            storageAdminClient.setPartitionAssignment(partitionIds, true, false);
+
             storageAdminClient.close();
             i++;
         }

--- a/waltz-storage/src/main/java/com/wepay/waltz/storage/client/StorageAdminClient.java
+++ b/waltz-storage/src/main/java/com/wepay/waltz/storage/client/StorageAdminClient.java
@@ -24,6 +24,7 @@ import com.wepay.waltz.storage.exception.StorageRpcException;
 import io.netty.handler.ssl.SslContext;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -47,23 +48,23 @@ public class StorageAdminClient extends StorageBaseClient {
 
     /**
      * Sets a partition's available flag.
-     * @param partitionId the partition id
+     * @param partitionIds the list of partition ids
      * @param isAvailable whether storage clients are allowed to read and write the partition
      * @return Future of Boolean
      */
-    public CompletableFuture<Object> setPartitionAvailable(int partitionId, boolean isAvailable) {
-        return call(new PartitionAvailableRequest(seqNum.getAndIncrement(), partitionId, isAvailable));
+    public CompletableFuture<Object> setPartitionAvailable(List<Integer> partitionIds, boolean isAvailable) {
+        return call(new PartitionAvailableRequest(seqNum.getAndIncrement(), partitionIds, isAvailable));
     }
 
     /**
      * Assign/unassign ownership of a partition for a storage client
-     * @param partitionId the partition id
+     * @param partitionIds the list of partition ids
      * @param isAssigned whether the storage node has ownership of the partition
      * @param deleteStorageFiles whether to delete the storage files within the partition
      * @return Future of Boolean
      */
-    public CompletableFuture<Object> setPartitionAssignment(int partitionId, boolean isAssigned, boolean deleteStorageFiles) {
-        return call(new PartitionAssignmentRequest(seqNum.getAndIncrement(), partitionId, isAssigned, deleteStorageFiles));
+    public CompletableFuture<Object> setPartitionAssignment(List<Integer> partitionIds, boolean isAssigned, boolean deleteStorageFiles) {
+        return call(new PartitionAssignmentRequest(seqNum.getAndIncrement(), partitionIds, isAssigned, deleteStorageFiles));
     }
 
     /**

--- a/waltz-storage/src/main/java/com/wepay/waltz/storage/common/message/admin/AdminMessageCodecV0.java
+++ b/waltz-storage/src/main/java/com/wepay/waltz/storage/common/message/admin/AdminMessageCodecV0.java
@@ -47,10 +47,10 @@ public class AdminMessageCodecV0 implements MessageCodec {
                 return new AdminOpenRequest(new UUID(reader.readLong(), reader.readLong()), reader.readInt());
 
             case AdminMessageType.PARTITION_AVAILABLE_REQUEST:
-                return new PartitionAvailableRequest(seqNum, reader.readInt(), reader.readBoolean());
+                return new PartitionAvailableRequest(seqNum, reader.readIntList(), reader.readBoolean());
 
             case AdminMessageType.PARTITION_ASSIGNMENT_REQUEST:
-                return new PartitionAssignmentRequest(seqNum, reader.readInt(), reader.readBoolean(), reader.readBoolean());
+                return new PartitionAssignmentRequest(seqNum, reader.readIntList(), reader.readBoolean(), reader.readBoolean());
 
             case AdminMessageType.RECORD_LIST_REQUEST:
                 return new RecordListRequest(seqNum, reader.readInt(), reader.readLong(), reader.readInt());
@@ -117,13 +117,13 @@ public class AdminMessageCodecV0 implements MessageCodec {
 
             case AdminMessageType.PARTITION_AVAILABLE_REQUEST:
                 PartitionAvailableRequest partitionAvailableRequest = (PartitionAvailableRequest) msg;
-                writer.writeInt(partitionAvailableRequest.partitionId);
+                writer.writeIntList(partitionAvailableRequest.partitionsIds);
                 writer.writeBoolean(partitionAvailableRequest.toggled);
                 break;
 
             case AdminMessageType.PARTITION_ASSIGNMENT_REQUEST:
                 PartitionAssignmentRequest partitionAssignmentRequest = (PartitionAssignmentRequest) msg;
-                writer.writeInt(partitionAssignmentRequest.partitionId);
+                writer.writeIntList(partitionAssignmentRequest.partitionIds);
                 writer.writeBoolean(partitionAssignmentRequest.toggled);
                 writer.writeBoolean(partitionAssignmentRequest.deleteStorageFiles);
                 break;

--- a/waltz-storage/src/main/java/com/wepay/waltz/storage/common/message/admin/PartitionAssignmentRequest.java
+++ b/waltz-storage/src/main/java/com/wepay/waltz/storage/common/message/admin/PartitionAssignmentRequest.java
@@ -1,5 +1,7 @@
 package com.wepay.waltz.storage.common.message.admin;
 
+import java.util.List;
+
 /**
  * An subclass of {@link AdminMessage} that updates the partition ownership of a given storage node.
  * Toggle true to add a partition ownership to a storage node. Toggle false to remove a partition
@@ -9,14 +11,14 @@ package com.wepay.waltz.storage.common.message.admin;
  */
 public class PartitionAssignmentRequest extends AdminMessage {
 
-    public final int partitionId;
+    public final List<Integer> partitionIds;
     public final boolean toggled;
     public final boolean deleteStorageFiles;
 
-    public PartitionAssignmentRequest(long seqNum, int partitionId, boolean toggled, boolean deleteStorageFiles) {
+    public PartitionAssignmentRequest(long seqNum, List<Integer> partitionIds, boolean toggled, boolean deleteStorageFiles) {
         super(seqNum);
 
-        this.partitionId = partitionId;
+        this.partitionIds = partitionIds;
         this.toggled = toggled;
         this.deleteStorageFiles = deleteStorageFiles;
     }

--- a/waltz-storage/src/main/java/com/wepay/waltz/storage/common/message/admin/PartitionAvailableRequest.java
+++ b/waltz-storage/src/main/java/com/wepay/waltz/storage/common/message/admin/PartitionAvailableRequest.java
@@ -1,5 +1,7 @@
 package com.wepay.waltz.storage.common.message.admin;
 
+import java.util.List;
+
 /**
  * An subclass of {@link AdminMessage} that updates the partition availability of a given storage node.
  * Toggle true to allow the storage node to read and write a partition. Toggle false to
@@ -7,13 +9,13 @@ package com.wepay.waltz.storage.common.message.admin;
  */
 public class PartitionAvailableRequest extends AdminMessage {
 
-    public final int partitionId;
+    public final List<Integer> partitionsIds;
     public final boolean toggled;
 
-    public PartitionAvailableRequest(long seqNum, int partitionId, boolean toggled) {
+    public PartitionAvailableRequest(long seqNum, List<Integer> partitionIds, boolean toggled) {
         super(seqNum);
 
-        this.partitionId = partitionId;
+        this.partitionsIds = partitionIds;
         this.toggled = toggled;
     }
 

--- a/waltz-storage/src/main/java/com/wepay/waltz/storage/server/internal/AdminServerHandler.java
+++ b/waltz-storage/src/main/java/com/wepay/waltz/storage/server/internal/AdminServerHandler.java
@@ -75,7 +75,7 @@ public class AdminServerHandler extends MessageHandler {
 
             case AdminMessageType.PARTITION_AVAILABLE_REQUEST:
                 try {
-                    storageManager.setPartitionAvailable(((PartitionAvailableRequest) msg).partitionId, ((PartitionAvailableRequest) msg).toggled);
+                    storageManager.setPartitionAvailable(((PartitionAvailableRequest) msg).partitionsIds, ((PartitionAvailableRequest) msg).toggled);
                     success(message);
 
                 } catch (ConcurrentUpdateException | IOException | StorageException ex) {
@@ -85,7 +85,7 @@ public class AdminServerHandler extends MessageHandler {
 
             case AdminMessageType.PARTITION_ASSIGNMENT_REQUEST:
                 try {
-                    storageManager.setPartitionAssignment(((PartitionAssignmentRequest) msg).partitionId, ((PartitionAssignmentRequest) msg).toggled, ((PartitionAssignmentRequest) msg).deleteStorageFiles);
+                    storageManager.setPartitionAssignment(((PartitionAssignmentRequest) msg).partitionIds, ((PartitionAssignmentRequest) msg).toggled, ((PartitionAssignmentRequest) msg).deleteStorageFiles);
                     success(message);
 
                 } catch (ConcurrentUpdateException | IOException | StorageException ex) {

--- a/waltz-storage/src/test/java/com/wepay/waltz/storage/client/StorageAdminClientTest.java
+++ b/waltz-storage/src/test/java/com/wepay/waltz/storage/client/StorageAdminClientTest.java
@@ -24,10 +24,14 @@ import org.junit.Test;
 import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -111,9 +115,9 @@ public final class StorageAdminClientTest {
             int adminPort = waltzStorage.adminPort;
             StorageAdminClient adminClient = new StorageAdminClient(host, adminPort, sslCtx, key, NUM_PARTITIONS);
             adminClient.open();
-            for (int i = 0; i < NUM_PARTITIONS; i++) {
-                adminClient.setPartitionAssignment(i, true, false).get();
-            }
+            List<Integer> partitionIds = IntStream.range(0, NUM_PARTITIONS).boxed().collect(Collectors.toList());
+            adminClient.setPartitionAssignment(partitionIds, true, false).get();
+
 
             ArrayList<Record> records = ClientUtil.makeRecords(0, 10);
             int port = waltzStorage.port;
@@ -128,7 +132,7 @@ public final class StorageAdminClientTest {
             assertEquals(record.header, returnedRecord.header);
             assertArrayEquals(record.data, returnedRecord.data);
             assertEquals(record.checksum, returnedRecord.checksum);
-            adminClient.setPartitionAvailable(0, false).get();
+            adminClient.setPartitionAvailable(Arrays.asList(0), false).get();
             try {
                 client.getRecord(SESSION_ID, 0, records.get(0).transactionId).get();
                 fail();
@@ -155,9 +159,8 @@ public final class StorageAdminClientTest {
             int adminPort = waltzStorage.adminPort;
             StorageAdminClient adminClient = new StorageAdminClient(host, adminPort, sslCtx, key, NUM_PARTITIONS);
             adminClient.open();
-            for (int i = 0; i < NUM_PARTITIONS; i++) {
-                adminClient.setPartitionAssignment(i, true, false).get();
-            }
+            List<Integer> partitionIds = IntStream.range(0, NUM_PARTITIONS).boxed().collect(Collectors.toList());
+            adminClient.setPartitionAssignment(partitionIds, true, false).get();
 
             ArrayList<Record> records = ClientUtil.makeRecords(0, 10);
             ArrayList<Record> records2 = ClientUtil.makeRecords(10, 20);
@@ -166,7 +169,7 @@ public final class StorageAdminClientTest {
             client.open();
             client.setLowWaterMark(SESSION_ID, 0, -1L).get();
             client.appendRecords(SESSION_ID, 0, records).get();
-            adminClient.setPartitionAvailable(0, false).get();
+            adminClient.setPartitionAvailable(Arrays.asList(0), false).get();
             try {
                 client.appendRecords(SESSION_ID, 0, records2).get();
                 fail();
@@ -195,9 +198,8 @@ public final class StorageAdminClientTest {
             int adminPort = waltzStorage.adminPort;
             StorageAdminClient adminClient = new StorageAdminClient(host, adminPort, sslCtx, key, NUM_PARTITIONS);
             adminClient.open();
-            for (int i = 0; i < NUM_PARTITIONS; i++) {
-                adminClient.setPartitionAssignment(i, true, false).get();
-            }
+            List<Integer> partitionIds = IntStream.range(0, NUM_PARTITIONS).boxed().collect(Collectors.toList());
+            adminClient.setPartitionAssignment(partitionIds, true, false).get();
 
             // Write records.
             ArrayList<Record> records = ClientUtil.makeRecords(0, 10);
@@ -239,9 +241,8 @@ public final class StorageAdminClientTest {
             int adminPort = waltzStorage.adminPort;
             StorageAdminClient adminClient = new StorageAdminClient(host, adminPort, sslCtx, key, NUM_PARTITIONS);
             adminClient.open();
-            for (int i = 0; i < NUM_PARTITIONS; i++) {
-                adminClient.setPartitionAssignment(i, true, false).get();
-            }
+            List<Integer> partitionIds = IntStream.range(0, NUM_PARTITIONS).boxed().collect(Collectors.toList());
+            adminClient.setPartitionAssignment(partitionIds, true, false).get();
 
             // Write records.
             ArrayList<Record> records = ClientUtil.makeRecords(0, 10);

--- a/waltz-storage/src/test/java/com/wepay/waltz/storage/client/StorageClientTest.java
+++ b/waltz-storage/src/test/java/com/wepay/waltz/storage/client/StorageClientTest.java
@@ -26,10 +26,14 @@ import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -119,7 +123,7 @@ public final class StorageClientTest {
             StorageAdminClient adminClient = new StorageAdminClient(host, adminPort, sslCtx, key, NUM_PARTITIONS);
             adminClient.open();
             for (int i = 0; i < NUM_PARTITIONS; i++) {
-                adminClient.setPartitionAssignment(i, true, false).get();
+                adminClient.setPartitionAssignment(Arrays.asList(i), true, false).get();
             }
 
             int port = waltzStorage.port;
@@ -233,9 +237,9 @@ public final class StorageClientTest {
             int adminPort = waltzStorage.adminPort;
             StorageAdminClient adminClient = new StorageAdminClient(host, adminPort, sslCtx, key, NUM_PARTITIONS);
             adminClient.open();
-            for (int i = 0; i < NUM_PARTITIONS; i++) {
-                adminClient.setPartitionAssignment(i, true, false).get();
-            }
+
+            List<Integer> partitionIds = IntStream.range(0, NUM_PARTITIONS).boxed().collect(Collectors.toList());
+            adminClient.setPartitionAssignment(partitionIds, true, false).get();
 
             int port = waltzStorage.port;
             StorageClient client = new StorageClient(host, port, sslCtx, key, NUM_PARTITIONS);
@@ -276,9 +280,9 @@ public final class StorageClientTest {
             int adminPort = waltzStorage.adminPort;
             StorageAdminClient adminClient = new StorageAdminClient(host, adminPort, sslCtx, key, NUM_PARTITIONS);
             adminClient.open();
-            for (int i = 0; i < NUM_PARTITIONS; i++) {
-                adminClient.setPartitionAssignment(i, true, false).get();
-            }
+
+            List<Integer> partitionIds = IntStream.range(0, NUM_PARTITIONS).boxed().collect(Collectors.toList());
+            adminClient.setPartitionAssignment(partitionIds, true, false).get();
 
             int port = waltzStorage.port;
             StorageClient client = new StorageClient(host, port, sslCtx, key, NUM_PARTITIONS);
@@ -327,9 +331,8 @@ public final class StorageClientTest {
             int adminPort = waltzStorage.adminPort;
             StorageAdminClient adminClient = new StorageAdminClient(host, adminPort, sslCtx, key, NUM_PARTITIONS);
             adminClient.open();
-            for (int i = 0; i < NUM_PARTITIONS; i++) {
-                adminClient.setPartitionAssignment(i, true, false).get();
-            }
+            List<Integer> partitionIds = IntStream.range(0, NUM_PARTITIONS).boxed().collect(Collectors.toList());
+            adminClient.setPartitionAssignment(partitionIds, true, false).get();
 
             int port = waltzStorage.port;
             StorageClient client = new StorageClient(host, port, sslCtx, key, NUM_PARTITIONS);
@@ -387,9 +390,8 @@ public final class StorageClientTest {
             int adminPort = waltzStorage.adminPort;
             StorageAdminClient adminClient = new StorageAdminClient(host, adminPort, sslCtx, key, NUM_PARTITIONS);
             adminClient.open();
-            for (int i = 0; i < NUM_PARTITIONS; i++) {
-                adminClient.setPartitionAssignment(i, true, false).get();
-            }
+            List<Integer> partitionIds = IntStream.range(0, NUM_PARTITIONS).boxed().collect(Collectors.toList());
+            adminClient.setPartitionAssignment(partitionIds, true, false).get();
 
             int port = waltzStorage.port;
             StorageClient client = new StorageClient(host, port, sslCtx, key, NUM_PARTITIONS);
@@ -444,9 +446,8 @@ public final class StorageClientTest {
             int adminPort = waltzStorage.adminPort;
             StorageAdminClient adminClient = new StorageAdminClient(host, adminPort, sslCtx, key, NUM_PARTITIONS);
             adminClient.open();
-            for (int i = 0; i < NUM_PARTITIONS; i++) {
-                adminClient.setPartitionAssignment(i, true, false).get();
-            }
+            List<Integer> partitionIds = IntStream.range(0, NUM_PARTITIONS).boxed().collect(Collectors.toList());
+            adminClient.setPartitionAssignment(partitionIds, true, false).get();
 
             int port = waltzStorage.port;
             StorageClient client = new StorageClient(host, port, sslCtx, key, NUM_PARTITIONS);

--- a/waltz-storage/src/test/java/com/wepay/waltz/storage/common/message/admin/AdminMessageCodecV0Test.java
+++ b/waltz-storage/src/test/java/com/wepay/waltz/storage/common/message/admin/AdminMessageCodecV0Test.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class AdminMessageCodecV0Test {
     private final AdminMessageCodecV0 codec = new AdminMessageCodecV0();
@@ -26,11 +27,11 @@ public class AdminMessageCodecV0Test {
 
     @Test
     public void testSetPartitionAvailableRequest() {
-        PartitionAvailableRequest partitionAvailableRequest1 = new PartitionAvailableRequest(2, 3, true);
+        PartitionAvailableRequest partitionAvailableRequest1 = new PartitionAvailableRequest(2, Arrays.asList(3, 4), true);
         PartitionAvailableRequest partitionAvailableRequest2 = encodeThenDecode(partitionAvailableRequest1);
         assertEquals(AdminMessageType.PARTITION_AVAILABLE_REQUEST, partitionAvailableRequest1.type());
         assertEquals(partitionAvailableRequest1.type(), partitionAvailableRequest2.type());
-        assertEquals(partitionAvailableRequest1.partitionId, partitionAvailableRequest2.partitionId);
+        assertTrue(partitionAvailableRequest1.partitionsIds.containsAll(partitionAvailableRequest2.partitionsIds));
         assertEquals(partitionAvailableRequest1.seqNum, partitionAvailableRequest2.seqNum);
         assertEquals(partitionAvailableRequest1.toggled, partitionAvailableRequest2.toggled);
     }
@@ -38,10 +39,10 @@ public class AdminMessageCodecV0Test {
     @Test
     public void testPartitionAssignmentRequest() {
         PartitionAssignmentRequest partitionAssignmentRequest1 = new PartitionAssignmentRequest(
-                rand.nextLong(), rand.nextInt(), rand.nextBoolean(), rand.nextBoolean());
+                rand.nextLong(), Arrays.asList(rand.nextInt()), rand.nextBoolean(), rand.nextBoolean());
         PartitionAssignmentRequest partitionAssignmentRequest2 = encodeThenDecode(partitionAssignmentRequest1);
         assertEquals(AdminMessageType.PARTITION_ASSIGNMENT_REQUEST, partitionAssignmentRequest1.type());
-        assertEquals(partitionAssignmentRequest1.partitionId, partitionAssignmentRequest2.partitionId);
+        assertTrue(partitionAssignmentRequest1.partitionIds.containsAll(partitionAssignmentRequest2.partitionIds));
         assertEquals(partitionAssignmentRequest1.seqNum, partitionAssignmentRequest2.seqNum);
         assertEquals(partitionAssignmentRequest1.toggled, partitionAssignmentRequest2.toggled);
         assertEquals(partitionAssignmentRequest1.deleteStorageFiles, partitionAssignmentRequest2.deleteStorageFiles);

--- a/waltz-storage/src/test/java/com/wepay/waltz/storage/server/internal/StorageManagerTest.java
+++ b/waltz-storage/src/test/java/com/wepay/waltz/storage/server/internal/StorageManagerTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
@@ -72,9 +73,9 @@ public class StorageManagerTest {
 
         try {
             manager.open(clusterKey, NUM_PARTITION);
-            manager.setPartitionAssignment(partitionId, true, false);
+            manager.setPartitionAssignment(Arrays.asList(partitionId), true, false);
 
-            manager.setPartitionAssignment(partitionId, false, false);
+            manager.setPartitionAssignment(Arrays.asList(partitionId), false, false);
 
             assertTrue(segPath.toFile().exists());
             assertTrue(idxPath.toFile().exists());
@@ -96,9 +97,9 @@ public class StorageManagerTest {
 
         try {
             manager.open(clusterKey, NUM_PARTITION);
-            manager.setPartitionAssignment(partitionId, true, false);
+            manager.setPartitionAssignment(Arrays.asList(partitionId), true, false);
 
-            manager.setPartitionAssignment(partitionId, false, true);
+            manager.setPartitionAssignment(Arrays.asList(partitionId), false, true);
 
             assertFalse(segPath.toFile().exists());
             assertFalse(idxPath.toFile().exists());

--- a/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
+++ b/waltz-test/src/main/java/com/wepay/waltz/test/util/IntegrationTestHelper.java
@@ -30,7 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * This an utility class that helps integration test. It is common
@@ -422,13 +423,8 @@ public class IntegrationTestHelper {
     public void setWaltzStorageAssignmentWithPort(int adminPort, boolean isAssigned) throws Exception {
         StorageAdminClient storageAdminClient = getStorageAdminClientWithAdminPort(adminPort);
 
-        List<Future<?>> futures = new ArrayList<>(numPartitions);
-        for (int i = 0; i < numPartitions; i++) {
-            futures.add(storageAdminClient.setPartitionAssignment(i, isAssigned, isAssigned ? false : true));
-        }
-        for (Future<?> future : futures) {
-            future.get();
-        }
+        List<Integer> partitionIds = IntStream.range(0, numPartitions).boxed().collect(Collectors.toList());
+        storageAdminClient.setPartitionAssignment(partitionIds, isAssigned, isAssigned ? false : true).get();
     }
 
     public void closeAll() throws Exception {

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/CliUtils.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/CliUtils.java
@@ -51,12 +51,11 @@ public final class CliUtils {
 
         for (String range : ranges) {
             if (range.contains("-")) {
-                int min = Integer.parseInt(range.split("-")[0]);
-                int max = Integer.parseInt(range.split("-")[1]);
+                int min = Integer.parseInt(range.split("-")[0].trim());
+                int max = Integer.parseInt(range.split("-")[1].trim());
                 IntStream.rangeClosed(min, max).forEach(partitions::add);
-
             } else {
-                partitions.add(Integer.parseInt(range));
+                partitions.add(Integer.parseInt(range.trim()));
             }
         }
 

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/storage/StorageCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/storage/StorageCliTest.java
@@ -188,7 +188,6 @@ public final class StorageCliTest {
         int numPartitions = 5;
         IntegrationTestHelper helper = getIntegrationTestHelper(numPartitions);
         int partitionId1 = new Random().nextInt(helper.getNumPartitions());
-        // ensure partitionId2 is different from partitionId1
         int partitionId2 = (partitionId1 + 1) % helper.getNumPartitions();
 
 
@@ -419,8 +418,7 @@ public final class StorageCliTest {
         int numPartitions = 5;
         IntegrationTestHelper helper = getIntegrationTestHelper(numPartitions);
         int partitionId1 = new Random().nextInt(helper.getNumPartitions());
-        // ensure partitionId2 is different from partitionId1
-        int partitionId2 = (partitionId1 + 1 + new Random().nextInt(helper.getNumPartitions() - 2)) % helper.getNumPartitions();
+        int partitionId2 = (partitionId1 + 1) % helper.getNumPartitions();
 
         Properties cfgProperties = createProperties(helper.getZkConnectString(), helper.getZnodePath(), helper.getSslSetup());
         String configFilePath = IntegrationTestHelper.createYamlConfigFile(DIR_NAME, CONFIG_FILE_NAME, cfgProperties);


### PR DESCRIPTION
Multi-partition support added for following commands: add-partition, availability, remove-partition. 

Test cases modified to test this functionality.

**This PR is dependent on:** https://github.com/wepay/riff/pull/18 and **won't build before riff version 2.4.7 is introduced**

To test this change locally before the above mentioned PR is merged and riff version is increased:
1. pull the remote riff branch
2. remove signing plugin from build gradle file
3. inside riff directory: ./gradlew publishToMavenLocal
4. build this waltz branch (to see that all the tests are passing - including tests testing this PR)
5. export WALTZ_TEST_CLUSTER_NUM_PARTITIONS=5
6. bin/test-cluster.sh start
7. bin/storage-cli.sh remove-partition -c config/local-docker/waltz_cluster/waltz-tools.yml -s localhost:55281 -p 0,3
8. bin/storage-cli.sh add-partition -c config/local-docker/waltz_cluster/waltz-tools.yml -s localhost:55281 -p 0,3