### PR TITLE
Support for Java 11+ BouncyCastle dependency needed to create SelfSignedCertificate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ project.ext {
     riffVersion = '2.4.6'
     jacksonVersion = '2.9.6'
     jettyVersion = '9.4.12.v20180830'
+    bouncyCastle = '1.68'
     mainClass = 'Main'
     buildVersionFileName = "waltz-version.properties"
 }
@@ -217,6 +218,7 @@ project(':waltz-server') {
             "org.slf4j:slf4j-api:$slf4jVersion",
             "org.eclipse.jetty:jetty-server:$jettyVersion",
             "org.eclipse.jetty:jetty-servlet:$jettyVersion",
+            "org.bouncycastle:bcpkix-jdk15on:$bouncyCastle",
         )
 
         testCompile (
@@ -278,6 +280,7 @@ project(':waltz-storage') {
             "org.yaml:snakeyaml:$yamlVersion",
             "org.eclipse.jetty:jetty-server:$jettyVersion",
             "org.eclipse.jetty:jetty-servlet:$jettyVersion",
+            "org.bouncycastle:bcpkix-jdk15on:$bouncyCastle",
         )
 
         testCompile (
@@ -382,7 +385,8 @@ project(':waltz-client') {
             "com.wepay.riff:riff-config:$riffVersion",
             "com.wepay.zktools:zktools:$zkToolsVersion",
             "io.netty:netty-all:$nettyVersion",
-            "org.slf4j:slf4j-api:$slf4jVersion"
+            "org.slf4j:slf4j-api:$slf4jVersion",
+            "org.bouncycastle:bcpkix-jdk15on:$bouncyCastle",
         )
 
         testCompile (

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ project.ext {
     riffVersion = '2.4.6'
     jacksonVersion = '2.9.6'
     jettyVersion = '9.4.12.v20180830'
-    bouncyCastle = '1.68'
+    bouncyCastleVersion = '1.68'
     mainClass = 'Main'
     buildVersionFileName = "waltz-version.properties"
 }
@@ -218,7 +218,7 @@ project(':waltz-server') {
             "org.slf4j:slf4j-api:$slf4jVersion",
             "org.eclipse.jetty:jetty-server:$jettyVersion",
             "org.eclipse.jetty:jetty-servlet:$jettyVersion",
-            "org.bouncycastle:bcpkix-jdk15on:$bouncyCastle",
+            "org.bouncycastle:bcpkix-jdk15on:$bouncyCastleVersion",
         )
 
         testCompile (
@@ -280,7 +280,7 @@ project(':waltz-storage') {
             "org.yaml:snakeyaml:$yamlVersion",
             "org.eclipse.jetty:jetty-server:$jettyVersion",
             "org.eclipse.jetty:jetty-servlet:$jettyVersion",
-            "org.bouncycastle:bcpkix-jdk15on:$bouncyCastle",
+            "org.bouncycastle:bcpkix-jdk15on:$bouncyCastleVersion",
         )
 
         testCompile (
@@ -386,7 +386,7 @@ project(':waltz-client') {
             "com.wepay.zktools:zktools:$zkToolsVersion",
             "io.netty:netty-all:$nettyVersion",
             "org.slf4j:slf4j-api:$slf4jVersion",
-            "org.bouncycastle:bcpkix-jdk15on:$bouncyCastle",
+            "org.bouncycastle:bcpkix-jdk15on:$bouncyCastleVersion",
         )
 
         testCompile (


### PR DESCRIPTION
**PR:**
Waltz currently supports only Java 8. This PR introduces the option to operate WaltzClis locally on a newer Java version by resolving:

```
java.security.cert.CertificateException: No provider succeeded to generate a self-signed certificate.

Suppressed: java.lang.IllegalAccessError: class io.netty.handler.ssl.util.OpenJdkSelfSignedCertGenerator 
(in unnamed module @0x1796cf6c) cannot access class sun.security.x509.X509CertInfo (in module java.base) 
because module java.base does not export sun.security.x509 to unnamed module 

Caused by: java.lang.NoClassDefFoundError: org/bouncycastle/jce/provider/BouncyCastleProvider

```
This aims to ease testing of Waltz on machines with multiple Java versions.

Since Java 9, most of the JDK's internal APIs are inaccessible at compile time. Thus, when Netty tries to access sun.security.x509, the access is denied. If creation of a self signed certificate fails, Netty tries to use BouncyCastle, which was missing up till now. This behavior comes from Netty's [SelfSignedCertificate class constructor](https://netty.io/4.1/xref/io/netty/handler/ssl/util/SelfSignedCertificate.html) - line 220

**Other considered approaches:**

1. --add-exports
It is possible to export sun.security.x509 module with 
`--add-exports java.base/sun.security.x509=ALL-UNNAMED`
java option. This makes the module accessible in Netty. However, in the future this --add-exports option will no longer be supported and overall general consensus is to avoid calling Java internal classes directly.
2. Waltz Utils class
[getSslContext function](https://github.com/wepay/waltz/blob/fbb71bf6c1907c7d4cfe832a828464a776480ca7/waltz-common/src/main/java/com/wepay/waltz/common/util/Utils.java#L152) in Utils class could prevent creation of certificates all together, if keystore or truststore files are missing. As this function is only called by Waltz clients, the creation of certificates isn't needed. If we call `ClientSSL.createInsecureContext()` which returns `SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build()`, we get all we need. However this is also not a viable solution as we will be just postponing the problem for later, because Waltz Server and Waltz Store need to have keys generated while running on localhost. See [link](https://github.com/wepay/waltz/blob/fbb71bf6c1907c7d4cfe832a828464a776480ca7/waltz-server/src/main/java/com/wepay/waltz/server/WaltzServer.java#L419).


**How to Test:**
Be sure to have Java 9+ (Java 11 recommended) set as your default java version. [run `java -version` to check]
Run
`bin/test-cluster.sh clean` if you have older waltz cluster already in Docker
`bin/test-cluster.sh start` this should succeed. Without this fix you should see following error message:

> Error: Failed to add partition 0. 
> No provider succeeded to generate a self-signed certificate. See debug log for the root cause.

**Alternatively**, have a Waltz cluster that is already running. IntelliJ Run -> Edit Configurations -> point to appropriate Java version (Java 9+) and run StorageCli with following params:
`add-partition -c config/local-docker/waltz_cluster/waltz-tools.yml -s localhost:55281 -p 0`