### PR TITLE
Waltz 0.12.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.waltz
 sourceCompatibility=1.8
-version=0.11.2
+version=0.12.0


### PR DESCRIPTION
Changes include:
	•	Fix to populate correct "high-water-mark" metric in WaltzServer when the node is started/restarted.
	•	Introducing keep-alive messages between the NetworkClient and NetworkServer to keep the connection channel active.
	•	Few StorageCli's updated to accept multiple partitions (as comma separated) instead of one partition.
	•	Added extra logging to identify Mounting issues.