### PR TITLE
Specify $platform parameter to support running zookeeper with Apple M1

### DIFF
--- a/bin/docker/zookeeper.sh
+++ b/bin/docker/zookeeper.sh
@@ -9,9 +9,10 @@ imageName=zookeeper:$tag
 containerName=zk
 networkName=waltz-network
 ports=42181:2181
+platform=linux/amd64
 
 runContainer() {
-    docker run --network=$networkName -p $ports --name $containerName -d $imageName
+    docker run --network=$networkName -p $ports --platform $platform --name $containerName -d $imageName
 }
 
 source $DIR/container.sh


### PR DESCRIPTION
the problem:
zookeeper 3.4 docker image does not support Apple M1 and triggers error `no matching manifest for linux/arm64/v8 in the manifest list entries`
the fix:
add parameter `platform=linux/amd64` to `docker run` command