### PR TITLE
Health check of Storesession fix

### DIFF
--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
@@ -109,8 +109,8 @@ public class StoreSessionManager {
     }
 
     /**
-     * Returns true if the store session manager is healthy, i.e., there is no recovery error currently.
-     * Returns false vice versa , i.e., no session is running
+     * Returns true if the store session manager is healthy, i.e., when a session is open and running,
+     * while there is no recovery or generation mismatch error. False otherwise.
      * @return
      */
     public boolean isHealthy() {

--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
@@ -110,6 +110,7 @@ public class StoreSessionManager {
 
     /**
      * Returns true if the store session manager is healthy, i.e., there is no recovery error currently.
+     * Returns false vice versa , i.e., no session is running
      * @return
      */
     public boolean isHealthy() {

--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
@@ -228,7 +228,6 @@ public class StoreSessionManager {
                 currentSession = session;
             } else {
                 if (session != null) {
-                    healthy = false;
                     session.close();
                 }
             }

--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
@@ -80,6 +80,7 @@ public class StoreSessionManager {
                     currentSession = null;
                 }
             }
+            healthy = false;
             backoffTimer.close();
         }
     }
@@ -138,6 +139,7 @@ public class StoreSessionManager {
 
                 createSession(generation.get());
             }
+            healthy = false;
             throw new StoreSessionManagerException();
         }
     }
@@ -204,19 +206,14 @@ public class StoreSessionManager {
                     }
                 }
 
-           } catch (GenerationMismatchException ex) {
-                if (session != null) {
-                    session.close();
-                }
-                throw ex;
-            } catch (RecoveryFailedException ex) {
+           } catch (GenerationMismatchException | RecoveryFailedException ex) {
                 healthy = false;
                 if (session != null) {
                     session.close();
                 }
                 throw ex;
-
             } catch (Exception ex) {
+                healthy = false;
                 if (session != null) {
                     session.close();
                 }
@@ -230,6 +227,7 @@ public class StoreSessionManager {
                 currentSession = session;
             } else {
                 if (session != null) {
+                    healthy = false;
                     session.close();
                 }
             }


### PR DESCRIPTION
#### Problem
The old method doesn't return the correct information if a Partition is closed. 
Because in the underlying methods, even if the StoreSessionManager is not currently running (i.e. if it was closed), the StoreSessionManager.isHealthy() method will returns true.  
e.g. when the clusters were deleted, the `healthy` state remains `true`
`{"server-health-check":{"healthy":true,"zookeeper":true,"partitions":{"0":false,"1":false,"2":false,"3":false,"4":false}}}`

#### Testing
Steps to locally verify functionality of this PR:

1. Start a new cluster with multiple partitions (delete old waltz containers if needed):
`export WALTZ_TEST_CLUSTER_NUM_PARTITIONS=5`
`bin/test-cluster.sh start`
2. Stop and start server node couple of times (to increase generation value) `./bin/zookeeper-cli.sh list -c config/local-docker/waltz-tools.yml` (command to check the generation number)
3. Delete waltz cluster `bin/zookeeper-cli.sh delete -n waltz_cluster --cli-config-path ./config/local-docker/waltz-tools.yml`
4. Create waltz cluster `bin/zookeeper-cli.sh create -p 5 -n waltz_cluster --cli-config-path ./config/local-docker/waltz-tools.yml`
5. Stop and delete waltz store node docker container 
6. start store node `./bin/docker/waltz-storage.sh start waltz_cluster 55280`

