### PR TITLE
un-register metrics after partitions are closed

### DIFF
--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
@@ -126,8 +126,6 @@ public class Partition {
      * stopped successfully..
      */
     public CompletableFuture<Boolean> closeAsync() {
-        // Un-register metrics
-        unregisterMetrics();
 
         if (running.compareAndSet(true, false)) {
             storePartition.close();
@@ -138,7 +136,10 @@ public class Partition {
 
             feedSync.close();
 
-            CompletableFuture.allOf(f1, f2, f3).whenComplete((v, t) -> closeFuture.complete(Boolean.TRUE));
+            CompletableFuture.allOf(f1, f2, f3)
+                    // Un-register metrics
+                    .whenComplete((v, t) -> unregisterMetrics())
+                    .whenComplete((v, t) -> closeFuture.complete(Boolean.TRUE));
         }
         return closeFuture;
     }


### PR DESCRIPTION
#### Fix
After consulted SRE, we found that Grafana won't be able to populate the `/health` endpoint. This PR changes the execution order when `closeAsync` is triggered by un-registering metrics after Partitions and all Tasks are closed or stopped.

#### Testing
Reuse `@Test testFlushAppendQueueAlreadyClosed()` to check if the sequence of steps is expected. Output statement is removed from the commit after testing.

``` java
CompletableFuture.allOf(f1, f2, f3)
        // Un-register metrics
        .whenComplete((v, t) -> {
                        System.out.println("before unregister " + REGISTRY.getGauges().size());
                        unregisterMetrics();
                        System.out.println("after unregister " + REGISTRY.getGauges().size());
                    })
        .whenComplete((v, t) -> closeFuture.complete(Boolean.TRUE));
```

Output 
before unregister 9
after unregister 0