### PR TITLE
Health check of Storesession fix - Follow up

### DIFF
--- a/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/store/internal/StoreSessionManager.java
@@ -140,7 +140,6 @@ public class StoreSessionManager {
 
                 createSession(generation.get());
             }
-            healthy = false;
             throw new StoreSessionManagerException();
         }
     }


### PR DESCRIPTION
### Follow up of [PR #162 ](https://github.com/wepay/waltz/pull/162)

#### Problem
 StoreSessionManager.getStoreSession() function should not be used to set the `healthy` state to `True` or `False`

#### Fix
`healthy = false` removed from getStoreSession()

