### PR TITLE
Release to Maven Central automation

### DIFF
--- a/.github/workflows/publish-and-release-to-maven-central.yml
+++ b/.github/workflows/publish-and-release-to-maven-central.yml
@@ -1,0 +1,138 @@
+name: Publish package to the Maven Central Repository
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  build:
+    if: "contains(github.event.head_commit.message, 'EXECUTE PUBLISH JOB')"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      #Run JDK configuration
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      #Gradle cache configuration
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      #Authorizing gradlew files
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      #Build project
+      - name: Build with Gradle
+        run: ./gradlew build
+
+  publish:
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      #Run JDK configuration
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      #Gradle cache configuration
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      #Authorize gradlew files
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      #Decode the secret key
+      - name: Decode
+        run: |
+          trap 'rm ~/.gradle/private.pgp' EXIT
+          echo "$SIGNING_SECRET_KEY_RING_FILE" > ~/.gradle/private.pgp
+          gpg --quiet --import --no-tty --batch --yes ~/.gradle/private.pgp
+          gpg --quiet --keyring secring.gpg --export-secret-keys --batch --pinentry-mode=loopback --passphrase  "$OSSRH_GPG_SECRET_KEY_PASSWORD" > ~/.gnupg/secring.gpg
+        env:
+          SIGNING_SECRET_KEY_RING_FILE: ${{ secrets.LEDGER_INFRA_SIGNING_SECRET_KEY_RING_FILE }}
+          OSSRH_GPG_SECRET_KEY_PASSWORD: ${{ secrets.LEDGER_INFRA_OSSRH_GPG_SECRET_KEY_PASSWORD }}
+
+      #Modify gradle.build to accept env variables
+      - name: Modify gradle.build
+        run: |
+          sed -i 's/username findProperty('\''ossrhUsername'\'')?: '\'''\''/username findProperty("ossrhUsername")?: System.getenv("OSSRH_USERNAME")/g' "build.gradle"
+          sed -i 's/password findProperty('\''ossrhPassword'\'')?: '\'''\''/password findProperty("ossrhPassword")?: System.getenv("OSSRH_PASSWORD")/g' "build.gradle"
+          cat "build.gradle"
+      #Publish project
+      - name: Publish
+        run: ./gradlew publish -PmySecureRepositoryUsername="$OSSRH_USERNAME" -PmySecureRepositoryPassword="$OSSRH_PASSWORD" -Psigning.keyId="$SIGNING_KEY_ID" -Psigning.password="$OSSRH_GPG_SECRET_KEY_PASSWORD" -Psigning.secretKeyRingFile=$(echo ~/.gnupg/secring.gpg)
+        env:
+          OSSRH_USERNAME: ${{ secrets.LEDGER_INFRA_OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.LEDGER_INFRA_OSSRH_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.LEDGER_INFRA_SIGNING_KEY_ID }}
+          OSSRH_GPG_SECRET_KEY_PASSWORD: ${{ secrets.LEDGER_INFRA_OSSRH_GPG_SECRET_KEY_PASSWORD }}
+
+
+  release:
+    needs: publish
+    if: "contains(github.event.head_commit.message, 'EXECUTE RELEASE JOB')"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      #Run JDK configuration
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      #Gradle cache configuration
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      #Authorize gradlew files
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      #Modify gradle.build to inject nexus-staging plugin if not present
+      - name: Modify gradle.build
+        run: |
+          if ! grep -q "io.codearte.nexus-staging" "build.gradle"; then
+                  # Inject plugin
+                  sed -i '/plugins {/ a\
+                  id "io.codearte.nexus-staging" version "0.30.0"\n' "build.gradle"
+                  if ! grep -q "plugins {" "./build.gradle"; then
+                          echo "plugins {
+            id \"io.codearte.nexus-staging\" version \"0.30.0\"
+          }" >> ./build.gradle
+                  fi
+                  # Inject plugin code
+                  echo "nexusStaging {
+            serverUrl = \"https://oss.sonatype.org/service/local/\"
+            username = findProperty(\"ossrhUsername\") ?: System.getenv(\"OSSRH_USERNAME\")
+            password = findProperty(\"ossrhPassword\") ?: System.getenv(\"OSSRH_PASSWORD\")
+            packageGroup = \"com.wepay.waltz\"
+          }" >> "build.gradle"
+          fi
+          cat "build.gradle"
+      #Close and Release project in Sonatype
+      - name: Close and Release
+        run: ./gradlew closeAndReleaseRepository
+        env:
+          OSSRH_USERNAME: ${{ secrets.LEDGER_INFRA_OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.LEDGER_INFRA_OSSRH_PASSWORD }}

--- a/.github/workflows/publish-and-release-to-maven-central.yml
+++ b/.github/workflows/publish-and-release-to-maven-central.yml
@@ -74,6 +74,7 @@ jobs:
           sed -i 's/username findProperty('\''ossrhUsername'\'')?: '\'''\''/username findProperty("ossrhUsername")?: System.getenv("OSSRH_USERNAME")/g' "build.gradle"
           sed -i 's/password findProperty('\''ossrhPassword'\'')?: '\'''\''/password findProperty("ossrhPassword")?: System.getenv("OSSRH_PASSWORD")/g' "build.gradle"
           cat "build.gradle"
+
       #Publish project
       - name: Publish
         run: ./gradlew publish -PmySecureRepositoryUsername="$OSSRH_USERNAME" -PmySecureRepositoryPassword="$OSSRH_PASSWORD" -Psigning.keyId="$SIGNING_KEY_ID" -Psigning.password="$OSSRH_GPG_SECRET_KEY_PASSWORD" -Psigning.secretKeyRingFile=$(echo ~/.gnupg/secring.gpg)
@@ -112,24 +113,19 @@ jobs:
       #Modify gradle.build to inject nexus-staging plugin if not present
       - name: Modify gradle.build
         run: |
-          if ! grep -q "io.codearte.nexus-staging" "build.gradle"; then
-                  # Inject plugin
-                  sed -i '/plugins {/ a\
-                  id "io.codearte.nexus-staging" version "0.30.0"\n' "build.gradle"
-                  if ! grep -q "plugins {" "./build.gradle"; then
-                          echo "plugins {
-            id \"io.codearte.nexus-staging\" version \"0.30.0\"
-          }" >> ./build.gradle
-                  fi
-                  # Inject plugin code
-                  echo "nexusStaging {
-            serverUrl = \"https://oss.sonatype.org/service/local/\"
-            username = findProperty(\"ossrhUsername\") ?: System.getenv(\"OSSRH_USERNAME\")
-            password = findProperty(\"ossrhPassword\") ?: System.getenv(\"OSSRH_PASSWORD\")
-            packageGroup = \"com.wepay.waltz\"
-          }" >> "build.gradle"
+          if ! grep -q "gradle-nexus-staging-plugin" "build.gradle"; then
+              # Inject plugin
+              awk '/classpath / && !x {print "classpath \"io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0\""; x=1} 1' "build.gradle" > tmp && mv tmp "build.gradle"
+              # Inject plugin code
+              echo "apply plugin: 'io.codearte.nexus-staging'
+              nexusStaging {
+                   serverUrl = \"https://oss.sonatype.org/service/local/\"
+                   username = findProperty(\"ossrhUsername\") ?: System.getenv(\"OSSRH_USERNAME\")
+                   password = findProperty(\"ossrhPassword\") ?: System.getenv(\"OSSRH_PASSWORD\")
+                   packageGroup = \"com.wepay\"
+              }" >> "build.gradle"
           fi
-          cat "build.gradle"
+
       #Close and Release project in Sonatype
       - name: Close and Release
         run: ./gradlew closeAndReleaseRepository

--- a/.github/workflows/publish-and-release-to-maven-central.yml
+++ b/.github/workflows/publish-and-release-to-maven-central.yml
@@ -73,7 +73,6 @@ jobs:
         run: |
           sed -i 's/username findProperty('\''ossrhUsername'\'')?: '\'''\''/username findProperty("ossrhUsername")?: System.getenv("OSSRH_USERNAME")/g' "build.gradle"
           sed -i 's/password findProperty('\''ossrhPassword'\'')?: '\'''\''/password findProperty("ossrhPassword")?: System.getenv("OSSRH_PASSWORD")/g' "build.gradle"
-          cat "build.gradle"
 
       #Publish project
       - name: Publish

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,21 @@
 # Publishing to Maven Central via Sonatype
 
+## Automated Approach
+
+GitHub Actions workflow automates publishing of a snapshot to [Sonatype](https://oss.sonatype.org/) and releases the build after closing it to Maven Central.
+
+Alternatively the workflow offers semi automation where it only publishes a snapshot to Sonatype where you can then [manage your builds](https://oss.sonatype.org/) (you may need to log in first) -- [read Manual Approach chapter](#Manual-Approach)
+
+Steps to follow:
+1. Bump up Waltz version
+2. Create a PR with title containing phrase:
+    + ``Execute Publish Job`` if you want to only publish to Sonatype and manage the build then yourself (semi automation)
+    + ``Execute Publish Job, Execute Release Job`` if you want to publish to Sonatype *AND* release the build to Maven Central (full automation)
+3. Get the PR approved and merge the code. The workflow will be executed automatically.
+4. [Verify](https://github.com/wepay/riff/actions) the workflow completed all its jobs. The workflow will typically run for a couple of minutes.
+
+## Manual Approach
+
 First, [follow the instructions for installing GPG and creating a key file](http://central.sonatype.org/pages/working-with-pgp-signatures.html).  You will need a version of GPG < 2.1.
 
 If this is your first time releasing, you will need to [create your JIRA account](https://issues.sonatype.org/secure/Signup!default.jspa), and then [create a JIRA ticket](https://issues.sonatype.org/secure/CreateIssue.jspa?issuetype=21&pid=10134) to request permission (for your account) to deploy artifacts to `com.wepay` (our groupId). For more information visit [OSSRH Guide](http://central.sonatype.org/pages/ossrh-guide.html).


### PR DESCRIPTION
GithubActions workflow to publish waltz to MavenCentral via Sonatype. 

Guide showing the workflow usability:
1. Bump up Waltz version in gradle.properties
2. Create a PR with a title containing phrase:
   + ``Execute Publish Job`` if you want to only publish to Sonatype and manage the build then yourself (semi automation)
   + ``Execute Publish Job, Execute Release Job`` if you want to publish to Sonatype *AND* release the build to Maven Central (full automation)
3. Get the PR approved and merge the code. The workflow will be executed automatically.
4. [Verify](https://github.com/wepay/waltz/actions) the workflow completed all its jobs. The workflow will typically run for a couple of minutes.

A copy of Riff PR: https://github.com/wepay/riff/pull/25
Tested on Waltz Repo with commented out release and deployment execution blocks:
https://github.com/wepay/waltz/actions/runs/2156023496