### PR TITLE
Client connection ordered by generation & seq number

### DIFF
--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
@@ -274,11 +274,9 @@ public class Partition {
      */
     public void registerLatestPartitionClient(PartitionClient client, int generation) {
         PartitionClientConnectionOrder partitionClientConnectionOrder = new PartitionClientConnectionOrder(client, generation);
-        logger.info("Partition id: " + this.partitionId);
         synchronized (partitionClientConnectionsOrder) {
             if (partitionClientConnectionOrder.compareClientOrder(partitionClientConnectionsOrder.get(client.clientId())) > 0) {
                 partitionClientConnectionsOrder.put(client.clientId(), partitionClientConnectionOrder);
-                logger.info("partitionClientConnectionsOrder added partitionClientConnectionOrder: " + partitionClientConnectionOrder);
             }
         }
     }
@@ -291,13 +289,10 @@ public class Partition {
     public boolean removePartitionClient(PartitionClient client) {
         synchronized (partitionClientConnectionsOrder) {
             PartitionClientConnectionOrder partitionClientConnectionOrder = partitionClientConnectionsOrder.get(client.clientId());
-            logger.info("IsEqual: " + client.equals(partitionClientConnectionOrder.client) +  ", client: " + client.seqNum());
             if (partitionClientConnectionOrder != null && client.equals(partitionClientConnectionOrder.client)) {
-                logger.info("partitionClientConnectionsOrder removed record for " + client.clientId() + ", partitionClientConnectionOrder: " + partitionClientConnectionOrder);
                 partitionClientConnectionsOrder.remove(client.clientId());
                 return true;
             }
-            logger.info("partitionClientConnectionsOrder didn't remove record for " + client.clientId() + " - seqNum: " + client.seqNum() + ", partitionClientConnectionOrder: " + partitionClientConnectionOrder);
             return false;
         }
     }

--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
@@ -815,7 +815,7 @@ public class Partition {
 
         @Override
         public String toString() {
-            return String.format("Generation: %s, SeqNum %s", generation, client.seqNum());
+            return String.format("Generation: %s, SeqNum: %s", generation, client.seqNum());
         }
     }
 }

--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Random;
 import java.util.stream.Collectors;
 
 
@@ -185,11 +184,7 @@ public class WaltzServerHandler extends MessageHandler implements PartitionClien
                             }
                             partition.registerLatestPartitionClient(this, ((MountRequest) msg).reqId.generation());
                         }
-                        if (msg.type() == MessageType.FEED_REQUEST) {
-                            Thread.sleep(30000);
-                            this.shutdown();
-                        }
-
+                        
                         partition.receiveMessage(msg, this);
 
                     } catch (PartitionClosedException | StorePartitionClosedException ex) {
@@ -239,12 +234,6 @@ public class WaltzServerHandler extends MessageHandler implements PartitionClien
 
         @Override
         public void onChannelInactive() {
-            Random r = new Random();
-            try {
-                Thread.sleep(r.nextInt(3) * 1000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
             synchronized (partitions) {
                 List<Integer> partitionClientsNotRemoved = new ArrayList<>();
                 for (Partition partition : partitions.values()) {

--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 
@@ -182,7 +183,11 @@ public class WaltzServerHandler extends MessageHandler implements PartitionClien
                             if (seqNum == null) {
                                 seqNum = ((MountRequest) msg).seqNum;
                             }
-                            partition.setPartitionClient(this);
+                            partition.registerLatestPartitionClient(this, ((MountRequest) msg).reqId.generation());
+                        }
+                        if (msg.type() == MessageType.FEED_REQUEST) {
+                            Thread.sleep(30000);
+                            this.shutdown();
                         }
 
                         partition.receiveMessage(msg, this);
@@ -234,6 +239,12 @@ public class WaltzServerHandler extends MessageHandler implements PartitionClien
 
         @Override
         public void onChannelInactive() {
+            Random r = new Random();
+            try {
+                Thread.sleep(r.nextInt(3) * 1000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
             synchronized (partitions) {
                 List<Integer> partitionClientsNotRemoved = new ArrayList<>();
                 for (Partition partition : partitions.values()) {

--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
@@ -182,9 +182,9 @@ public class WaltzServerHandler extends MessageHandler implements PartitionClien
                             if (seqNum == null) {
                                 seqNum = ((MountRequest) msg).seqNum;
                             }
-                            partition.registerLatestPartitionClient(this, ((MountRequest) msg).reqId.generation());
+                            partition.setPartitionClient(this, ((MountRequest) msg).reqId.generation());
                         }
-                        
+
                         partition.receiveMessage(msg, this);
 
                     } catch (PartitionClosedException | StorePartitionClosedException ex) {

--- a/waltz-server/src/test/java/com/wepay/waltz/server/internal/PartitionTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/server/internal/PartitionTest.java
@@ -95,7 +95,7 @@ public class PartitionTest {
             Message msg;
 
             MockPartitionClient partitionClient1 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId1);
-            partition.registerLatestPartitionClient(partitionClient1, DEFAULT_GENERATION);
+            partition.setPartitionClient(partitionClient1, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId1), clientHighWaterMark, partitionClient1.seqNum()),
                 partitionClient1
@@ -113,7 +113,7 @@ public class PartitionTest {
 
             // Connect the second client
             MockPartitionClient partitionClient2 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId2);
-            partition.registerLatestPartitionClient(partitionClient2, DEFAULT_GENERATION);
+            partition.setPartitionClient(partitionClient2, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId2), clientHighWaterMark, partitionClient2.seqNum),
                 partitionClient2
@@ -144,7 +144,7 @@ public class PartitionTest {
 
             // Connect the third client
             MockPartitionClient partitionClient3 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId3);
-            partition.registerLatestPartitionClient(partitionClient3, DEFAULT_GENERATION);
+            partition.setPartitionClient(partitionClient3, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId1), clientHighWaterMark + 1, partitionClient3.seqNum()),
                 partitionClient3
@@ -171,7 +171,7 @@ public class PartitionTest {
             Message msg;
 
             MockPartitionClient partitionClient = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId);
-            partition.registerLatestPartitionClient(partitionClient, DEFAULT_GENERATION);
+            partition.setPartitionClient(partitionClient, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId), clientHighWaterMark, partitionClient.seqNum()),
                 partitionClient
@@ -230,7 +230,7 @@ public class PartitionTest {
             Message msg;
 
             MockPartitionClient partitionClient = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId);
-            partition.registerLatestPartitionClient(partitionClient, DEFAULT_GENERATION);
+            partition.setPartitionClient(partitionClient, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId), clientHighWaterMark, partitionClient.seqNum()),
                 partitionClient
@@ -279,7 +279,7 @@ public class PartitionTest {
             Message msg;
 
             MockPartitionClient partitionClient1 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId1);
-            partition.registerLatestPartitionClient(partitionClient1, DEFAULT_GENERATION);
+            partition.setPartitionClient(partitionClient1, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId1), clientHighWaterMark, partitionClient1.seqNum()),
                 partitionClient1
@@ -328,7 +328,7 @@ public class PartitionTest {
 
             // Connect the second client to make sure that the first client is cleaned up.
             MockPartitionClient partitionClient2 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId2);
-            partition.registerLatestPartitionClient(partitionClient2, DEFAULT_GENERATION);
+            partition.setPartitionClient(partitionClient2, DEFAULT_GENERATION);
 
             // clientHighWaterMark of -1 to force the partitionClient2 to start from the beginning of the feed.
             partition.receiveMessage(
@@ -374,7 +374,7 @@ public class PartitionTest {
             Message msg;
 
             MockPartitionClient partitionClient1 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId1);
-            partition.registerLatestPartitionClient(partitionClient1, DEFAULT_GENERATION);
+            partition.setPartitionClient(partitionClient1, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId1), -1L, partitionClient1.seqNum()),
                 partitionClient1
@@ -382,7 +382,7 @@ public class PartitionTest {
 
             // Connect the second client to make sure that the first client is paused.
             MockPartitionClient partitionClient2 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId2);
-            partition.registerLatestPartitionClient(partitionClient2, DEFAULT_GENERATION);
+            partition.setPartitionClient(partitionClient2, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId2), -1L, partitionClient2.seqNum()),
                 partitionClient2
@@ -515,7 +515,7 @@ public class PartitionTest {
             Message msg;
 
             MockPartitionClient partitionClient = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId);
-            partition.registerLatestPartitionClient(partitionClient, DEFAULT_GENERATION);
+            partition.setPartitionClient(partitionClient, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId), clientHighWaterMark, partitionClient.seqNum()),
                 partitionClient
@@ -582,7 +582,7 @@ public class PartitionTest {
             Message msg;
 
             MockPartitionClient partitionClient1 = new MockPartitionClient(partitionClientSeqNum1, clientId);
-            partition.registerLatestPartitionClient(partitionClient1, partitionClientGenNum1);
+            partition.setPartitionClient(partitionClient1, partitionClientGenNum1);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId), clientHighWaterMark, partitionClient1.seqNum()),
                 partitionClient1
@@ -593,7 +593,7 @@ public class PartitionTest {
             assertEquals(MessageType.MOUNT_RESPONSE, msg.type());
 
             MockPartitionClient partitionClient2 = new MockPartitionClient(partitionClientSeqNum2, clientId);
-            partition.registerLatestPartitionClient(partitionClient2, partitionClientGenNum2);
+            partition.setPartitionClient(partitionClient2, partitionClientGenNum2);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId), clientHighWaterMark, partitionClient2.seqNum()),
                 partitionClient2
@@ -604,7 +604,7 @@ public class PartitionTest {
             assertEquals(MessageType.MOUNT_RESPONSE, msg.type());
 
             MockPartitionClient partitionClient3 = new MockPartitionClient(partitionClientSeqNum3, clientId);
-            partition.registerLatestPartitionClient(partitionClient3, partitionClientGenNum3);
+            partition.setPartitionClient(partitionClient3, partitionClientGenNum3);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId), clientHighWaterMark, partitionClient3.seqNum()),
                 partitionClient3

--- a/waltz-server/src/test/java/com/wepay/waltz/server/internal/PartitionTest.java
+++ b/waltz-server/src/test/java/com/wepay/waltz/server/internal/PartitionTest.java
@@ -41,6 +41,7 @@ public class PartitionTest {
     private static final int HEADER = 0;
     private static final int TRANSACTION_CACHE_SIZE = 33554432; // 32MB
     private static final int FEED_CACHE_SIZE = 33554432; // 32MB
+    private static final int DEFAULT_GENERATION = 0;
 
     private final AtomicLong seqNumGenerator = new AtomicLong(0);
     private final Random rand = new Random();
@@ -94,7 +95,7 @@ public class PartitionTest {
             Message msg;
 
             MockPartitionClient partitionClient1 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId1);
-            partition.setPartitionClient(partitionClient1);
+            partition.registerLatestPartitionClient(partitionClient1, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId1), clientHighWaterMark, partitionClient1.seqNum()),
                 partitionClient1
@@ -112,7 +113,7 @@ public class PartitionTest {
 
             // Connect the second client
             MockPartitionClient partitionClient2 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId2);
-            partition.setPartitionClient(partitionClient2);
+            partition.registerLatestPartitionClient(partitionClient2, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId2), clientHighWaterMark, partitionClient2.seqNum),
                 partitionClient2
@@ -125,7 +126,7 @@ public class PartitionTest {
             assertEquals(MessageType.MOUNT_RESPONSE, msg.type());
             assertEquals(MountResponse.PartitionState.READY, ((MountResponse) msg).partitionState);
 
-            // The first client should not see any feed yet because the feed request if not sent yet
+            // The first client should not see any feed yet because the feed request is not sent yet
             msg = partitionClient1.nextMessage(1);
             assertNull(msg);
 
@@ -143,7 +144,7 @@ public class PartitionTest {
 
             // Connect the third client
             MockPartitionClient partitionClient3 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId3);
-            partition.setPartitionClient(partitionClient3);
+            partition.registerLatestPartitionClient(partitionClient3, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId1), clientHighWaterMark + 1, partitionClient3.seqNum()),
                 partitionClient3
@@ -170,7 +171,7 @@ public class PartitionTest {
             Message msg;
 
             MockPartitionClient partitionClient = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId);
-            partition.setPartitionClient(partitionClient);
+            partition.registerLatestPartitionClient(partitionClient, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId), clientHighWaterMark, partitionClient.seqNum()),
                 partitionClient
@@ -229,7 +230,7 @@ public class PartitionTest {
             Message msg;
 
             MockPartitionClient partitionClient = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId);
-            partition.setPartitionClient(partitionClient);
+            partition.registerLatestPartitionClient(partitionClient, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId), clientHighWaterMark, partitionClient.seqNum()),
                 partitionClient
@@ -278,7 +279,7 @@ public class PartitionTest {
             Message msg;
 
             MockPartitionClient partitionClient1 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId1);
-            partition.setPartitionClient(partitionClient1);
+            partition.registerLatestPartitionClient(partitionClient1, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId1), clientHighWaterMark, partitionClient1.seqNum()),
                 partitionClient1
@@ -327,7 +328,7 @@ public class PartitionTest {
 
             // Connect the second client to make sure that the first client is cleaned up.
             MockPartitionClient partitionClient2 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId2);
-            partition.setPartitionClient(partitionClient2);
+            partition.registerLatestPartitionClient(partitionClient2, DEFAULT_GENERATION);
 
             // clientHighWaterMark of -1 to force the partitionClient2 to start from the beginning of the feed.
             partition.receiveMessage(
@@ -373,7 +374,7 @@ public class PartitionTest {
             Message msg;
 
             MockPartitionClient partitionClient1 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId1);
-            partition.setPartitionClient(partitionClient1);
+            partition.registerLatestPartitionClient(partitionClient1, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId1), -1L, partitionClient1.seqNum()),
                 partitionClient1
@@ -381,7 +382,7 @@ public class PartitionTest {
 
             // Connect the second client to make sure that the first client is paused.
             MockPartitionClient partitionClient2 = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId2);
-            partition.setPartitionClient(partitionClient2);
+            partition.registerLatestPartitionClient(partitionClient2, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId2), -1L, partitionClient2.seqNum()),
                 partitionClient2
@@ -514,7 +515,7 @@ public class PartitionTest {
             Message msg;
 
             MockPartitionClient partitionClient = new MockPartitionClient(seqNumGenerator.getAndIncrement(), clientId);
-            partition.setPartitionClient(partitionClient);
+            partition.registerLatestPartitionClient(partitionClient, DEFAULT_GENERATION);
             partition.receiveMessage(
                 new MountRequest(reqId(clientId), clientHighWaterMark, partitionClient.seqNum()),
                 partitionClient
@@ -557,6 +558,61 @@ public class PartitionTest {
             assertEquals(0, partition.getTotalRealtimeFeedContextRemoved());
             assertEquals(1, partition.getTotalCatchupFeedContextAdded());
             assertEquals(1, partition.getTotalCatchupFeedContextRemoved());
+
+        } finally {
+            if (!partition.isClosed()) {
+                partition.close();
+            }
+        }
+    }
+
+    @Test
+    public void testNewerClientReplacesOldClient() throws Exception {
+        Partition partition = new Partition(PARTITION_ID, storePartition, feedCachePartition, fetcher, config);
+        partition.open();
+        try {
+            int clientId = 0;
+            long partitionClientSeqNum1 = 0;
+            long partitionClientSeqNum2 = 1;
+            long partitionClientSeqNum3 = 0;
+            int partitionClientGenNum1 = 0;
+            int partitionClientGenNum2 = 0;
+            int partitionClientGenNum3 = 1;
+            long clientHighWaterMark = -1L;
+            Message msg;
+
+            MockPartitionClient partitionClient1 = new MockPartitionClient(partitionClientSeqNum1, clientId);
+            partition.registerLatestPartitionClient(partitionClient1, partitionClientGenNum1);
+            partition.receiveMessage(
+                new MountRequest(reqId(clientId), clientHighWaterMark, partitionClient1.seqNum()),
+                partitionClient1
+            );
+
+            msg = partitionClient1.nextMessage(TIMEOUT);
+            assertNotNull(msg);
+            assertEquals(MessageType.MOUNT_RESPONSE, msg.type());
+
+            MockPartitionClient partitionClient2 = new MockPartitionClient(partitionClientSeqNum2, clientId);
+            partition.registerLatestPartitionClient(partitionClient2, partitionClientGenNum2);
+            partition.receiveMessage(
+                new MountRequest(reqId(clientId), clientHighWaterMark, partitionClient2.seqNum()),
+                partitionClient2
+            );
+
+            msg = partitionClient2.nextMessage(TIMEOUT);
+            assertNotNull(msg);
+            assertEquals(MessageType.MOUNT_RESPONSE, msg.type());
+
+            MockPartitionClient partitionClient3 = new MockPartitionClient(partitionClientSeqNum3, clientId);
+            partition.registerLatestPartitionClient(partitionClient3, partitionClientGenNum3);
+            partition.receiveMessage(
+                new MountRequest(reqId(clientId), clientHighWaterMark, partitionClient3.seqNum()),
+                partitionClient3
+            );
+
+            msg = partitionClient3.nextMessage(TIMEOUT);
+            assertNotNull(msg);
+            assertEquals(MessageType.MOUNT_RESPONSE, msg.type());
 
         } finally {
             if (!partition.isClosed()) {


### PR DESCRIPTION
**Aim to fix:** We observed time related error when Waltz server is pushed from a cluster and rejoins quickly cluster again once connection to ZooKeeper is resumed. If partition mounting happens with the same seqNum number as was before the connection interruption, it is possible that WaltzServerHandler.OnChannelInactive is called after remounting happened and record of the newly registered NetworkClient is erased by the old NetworkClient.

**Description:** This PR aims to set order to NetworkClients that register clients to server Partitions. This means a NetworkClient with a higher order (N1) shouldn't be replaceable by NetworkClient with equal or lower order (N2) 
`N1.generation > N2.generation or (N1.generation == N2.generation and N1.seqNum >= N2.seqNum)`

**Testing:** New test case is added to verify partitions are successfully mounted even if old NetworkClient record haven't been cleared yet.

Further tests that involves connection shutdown:
<img width="1461" alt="Screen Shot 2022-04-14 at 11 56 49 AM" src="https://user-images.githubusercontent.com/26648775/163433332-f30ab768-9094-4801-b06c-d82fb4b28b0b.png">

<img width="1342" alt="Screen Shot 2022-04-13 at 9 42 39 PM" src="https://user-images.githubusercontent.com/26648775/163433443-ec5ee8a7-3c0a-481e-8390-628614b99451.png">