### PR TITLE
Added server partitions health validation check as part of ClusterCli.Verify

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalRpcClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/InternalRpcClient.java
@@ -112,6 +112,19 @@ public class InternalRpcClient extends InternalBaseClient implements RpcClient {
     }
 
     /**
+     * Gets the map of partitions assigned to the server with their health status
+     *
+     * @param serverEndpoint Server from which to fetch the assigned partitions
+     * @return Future which will contain the map of partitions and their health status when complete
+     * @throws InterruptedException if thrown by the {@code WaltzNetworkClient}
+     */
+    @Override
+    public Future<Map<Integer, Boolean>> getServerPartitionHealthStats(Endpoint serverEndpoint) throws InterruptedException {
+        WaltzNetworkClient networkClient = getNetworkClient(serverEndpoint);
+        return networkClient.getServerPartitionHealthStats();
+    }
+
+    /**
      * Adds given partition Ids as preferred partitions to the given Server Endpoint.
      * @param serverEndpoint Server Endpoint to add the partition to.
      * @param partitionIds The list of partition Ids.

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/RpcClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/RpcClient.java
@@ -22,6 +22,8 @@ public interface RpcClient {
 
     Future<List<Integer>> getServerPartitionAssignments(Endpoint serverEndpoint) throws InterruptedException;
 
+    Future<Map<Integer, Boolean>> getServerPartitionHealthStats(Endpoint serverEndpoint) throws InterruptedException;
+
     Future<Boolean> addPreferredPartition(Endpoint serverEndpoint, List<Integer> partitionIds) throws InterruptedException;
 
     Future<Boolean> removePreferredPartition(Endpoint serverEndpoint, List<Integer> partitionIds) throws InterruptedException;

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockRpcClient.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/mock/MockRpcClient.java
@@ -52,6 +52,11 @@ class MockRpcClient implements RpcClient {
     }
 
     @Override
+    public Future<Map<Integer, Boolean>> getServerPartitionHealthStats(Endpoint serverEndpoint) throws InterruptedException {
+        return CompletableFuture.completedFuture(new HashMap<>());
+    }
+
+    @Override
     public CompletableFuture<Boolean> addPreferredPartition(Endpoint serverEndpoint, List<Integer> partitionIds) throws InterruptedException {
         return CompletableFuture.completedFuture(true);
     }

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandler.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandler.java
@@ -16,6 +16,7 @@ import com.wepay.waltz.common.message.MessageCodecV0;
 import com.wepay.waltz.common.message.MessageCodecV1;
 import com.wepay.waltz.common.message.MessageCodecV2;
 import com.wepay.waltz.common.message.MessageCodecV3;
+import com.wepay.waltz.common.message.MessageCodecV4;
 import com.wepay.waltz.common.message.MessageType;
 import com.wepay.waltz.common.message.MountRequest;
 import com.wepay.waltz.common.message.MountResponse;
@@ -23,6 +24,7 @@ import com.wepay.waltz.common.message.RemovePreferredPartitionResponse;
 import com.wepay.waltz.common.message.ReqId;
 import com.wepay.waltz.common.message.TransactionDataResponse;
 import com.wepay.waltz.common.message.ServerPartitionsAssignmentResponse;
+import com.wepay.waltz.common.message.ServerPartitionsHealthStatResponse;
 import org.slf4j.Logger;
 
 import java.util.HashMap;
@@ -42,6 +44,7 @@ public class WaltzClientHandler extends MessageHandler {
         CODECS.put(MessageCodecV1.VERSION, MessageCodecV1.INSTANCE);
         CODECS.put(MessageCodecV2.VERSION, MessageCodecV2.INSTANCE);
         CODECS.put(MessageCodecV3.VERSION, MessageCodecV3.INSTANCE);
+        CODECS.put(MessageCodecV4.VERSION, MessageCodecV4.INSTANCE);
     }
 
     private static final String HELLO_MESSAGE = "Waltz Client";
@@ -156,6 +159,11 @@ public class WaltzClientHandler extends MessageHandler {
                     (RemovePreferredPartitionResponse) msg;
                 handlerCallbacks.onRemovePreferredPartitionResponseReceived(removePreferredPartitionResponse.result);
                 break;
+
+            case MessageType.SERVER_PARTITIONS_HEALTH_STAT_RESPONSE:
+                ServerPartitionsHealthStatResponse serverPartitionsHealthStatResponse =
+                    (ServerPartitionsHealthStatResponse) msg;
+                handlerCallbacks.onServerPartitionsHealthStatsReceived(serverPartitionsHealthStatResponse.serverPartitionHealthStats);
 
             default:
                 throw new IllegalArgumentException("message not handled: messageType=" + msg.type());

--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandlerCallbacks.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandlerCallbacks.java
@@ -111,4 +111,10 @@ public interface WaltzClientHandlerCallbacks extends MessageHandlerCallbacks {
      * @param result true if preferred partition removal was successful, otherwise false.
      */
     void onRemovePreferredPartitionResponseReceived(Boolean result);
+
+    /**
+     * Handles the received partition health check response message.
+     * @param partitions Map of all the partitions this server is assigned to and their health status.
+     */
+    void onServerPartitionsHealthStatsReceived(Map<Integer, Boolean> partitions);
 }

--- a/waltz-client/src/test/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBCTest.java
+++ b/waltz-client/src/test/java/com/wepay/waltz/client/AbstractClientCallbacksForJDBCTest.java
@@ -495,6 +495,11 @@ public class AbstractClientCallbacksForJDBCTest {
             }
 
             @Override
+            public Future<Map<Integer, Boolean>> getServerPartitionHealthStats(Endpoint serverEndpoint) throws InterruptedException {
+                return CompletableFuture.completedFuture(new HashMap<>());
+            }
+
+            @Override
             public CompletableFuture<Boolean> addPreferredPartition(Endpoint serverEndpoint, List<Integer> partitionIds) throws InterruptedException {
                 return CompletableFuture.completedFuture(true);
             }

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageCodecV4.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageCodecV4.java
@@ -1,0 +1,331 @@
+package com.wepay.waltz.common.message;
+
+import com.wepay.riff.network.Message;
+import com.wepay.riff.network.MessageAttributeReader;
+import com.wepay.riff.network.MessageAttributeWriter;
+import com.wepay.riff.network.MessageCodec;
+import com.wepay.waltz.common.util.Utils;
+import com.wepay.waltz.exception.RpcException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MessageCodecV4 implements MessageCodec {
+
+    public static final short VERSION = 4;
+    public static final MessageCodecV4 INSTANCE = new MessageCodecV4();
+
+    private static final byte MAGIC_BYTE = 'L';
+
+    @Override
+    public byte magicByte() {
+        return MAGIC_BYTE;
+    }
+
+    @Override
+    public short version() {
+        return VERSION;
+    }
+
+    @Override
+    public Message decode(MessageAttributeReader reader) {
+        // Decode common attributes
+        byte messageType = reader.readByte();
+        ReqId reqId = ReqId.readFrom(reader);
+        long transactionId;
+        int header;
+        byte[] data;
+        int checksum;
+        boolean result;
+
+        switch (messageType) {
+            case MessageType.MOUNT_REQUEST:
+                long clientHighWaterMark = reader.readLong();
+                long seqNum = reader.readLong();
+                return new MountRequest(reqId, clientHighWaterMark, seqNum);
+
+            case MessageType.MOUNT_RESPONSE:
+                int partitionState = reader.readInt();
+                return new MountResponse(reqId, partitionState);
+
+            case MessageType.APPEND_REQUEST:
+                transactionId = reader.readLong(); // client High-water mark
+                int[] writeLockRequest = reader.readIntArray();
+                int[] readLockRequest = reader.readIntArray();
+                int[] appendLockRequest = reader.readIntArray();
+                header = reader.readInt();
+                data = reader.readByteArray();
+                checksum = reader.readInt();
+                Utils.verifyChecksum(messageType, data, checksum);
+                return new AppendRequest(
+                    reqId,
+                    transactionId,
+                    writeLockRequest,
+                    readLockRequest,
+                    appendLockRequest,
+                    header,
+                    data,
+                    checksum
+                );
+
+            case MessageType.FEED_REQUEST:
+                transactionId = reader.readLong(); // client High-water mark
+                return new FeedRequest(reqId, transactionId);
+
+            case MessageType.FEED_DATA:
+                transactionId = reader.readLong();
+                header = reader.readInt();
+                return new FeedData(reqId, transactionId, header);
+
+            case MessageType.FEED_SUSPENDED:
+                return new FeedSuspended(reqId);
+
+            case MessageType.TRANSACTION_DATA_REQUEST:
+                transactionId = reader.readLong();
+                return new TransactionDataRequest(reqId, transactionId);
+
+            case MessageType.TRANSACTION_DATA_RESPONSE:
+                transactionId = reader.readLong();
+                if (reader.readBoolean()) {
+                    data = reader.readByteArray();
+                    checksum = reader.readInt();
+                    Utils.verifyChecksum(messageType, data, checksum);
+                    return new TransactionDataResponse(reqId, transactionId, data, checksum);
+                } else {
+                    RpcException exception = new RpcException(reader.readString());
+                    return new TransactionDataResponse(reqId, transactionId, exception);
+                }
+
+            case MessageType.FLUSH_REQUEST:
+                return new FlushRequest(reqId);
+
+            case MessageType.FLUSH_RESPONSE:
+                transactionId = reader.readLong();
+                return new FlushResponse(reqId, transactionId);
+
+            case MessageType.HIGH_WATER_MARK_REQUEST:
+                return new HighWaterMarkRequest(reqId);
+
+            case MessageType.HIGH_WATER_MARK_RESPONSE:
+                transactionId = reader.readLong();
+                return new HighWaterMarkResponse(reqId, transactionId);
+
+            case MessageType.LOCK_FAILURE:
+                transactionId = reader.readLong();
+                return new LockFailure(reqId, transactionId);
+
+            case MessageType.CHECK_STORAGE_CONNECTIVITY_REQUEST:
+                return new CheckStorageConnectivityRequest(reqId);
+
+            case MessageType.CHECK_STORAGE_CONNECTIVITY_RESPONSE:
+                int size = reader.readInt();
+                Map<String, Boolean> storageConnectivityMap = new HashMap<>();
+                for (int i = 0; i < size; i++) {
+                    storageConnectivityMap.put(reader.readString(), reader.readBoolean());
+                }
+                return new CheckStorageConnectivityResponse(reqId, storageConnectivityMap);
+
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST:
+                return new ServerPartitionsAssignmentRequest(reqId);
+
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_RESPONSE:
+                return new ServerPartitionsAssignmentResponse(reqId, buildListReader(reader));
+
+            case MessageType.SERVER_PARTITIONS_HEALTH_STAT_REQUEST:
+                return new ServerPartitionsHealthStatRequest(reqId);
+
+            case MessageType.SERVER_PARTITIONS_HEALTH_STAT_RESPONSE:
+                size = reader.readInt();
+                Map<Integer, Boolean> partitionHealthStats = new HashMap<>();
+                for (int i = 0; i < size; i++) {
+                    partitionHealthStats.put(reader.readInt(), reader.readBoolean());
+                }
+                return new ServerPartitionsHealthStatResponse(reqId, partitionHealthStats);
+
+            case MessageType.ADD_PREFERRED_PARTITION_REQUEST:
+                return new AddPreferredPartitionRequest(reqId, buildListReader(reader));
+
+            case MessageType.ADD_PREFERRED_PARTITION_RESPONSE:
+                result = reader.readBoolean();
+                return new AddPreferredPartitionResponse(reqId, result);
+
+            case MessageType.REMOVE_PREFERRED_PARTITION_REQUEST:
+                return new RemovePreferredPartitionRequest(reqId, buildListReader(reader));
+
+            case MessageType.REMOVE_PREFERRED_PARTITION_RESPONSE:
+                result = reader.readBoolean();
+                return new RemovePreferredPartitionResponse(reqId, result);
+
+            default:
+                throw new IllegalStateException("unknown message type: " + messageType);
+        }
+    }
+
+    @Override
+    public void encode(Message msg, MessageAttributeWriter writer) {
+        // Encode common attributes
+        writer.writeByte(msg.type());
+        ((AbstractMessage) msg).reqId.writeTo(writer);
+
+        switch (msg.type()) {
+            case MessageType.MOUNT_REQUEST:
+                MountRequest mountRequest = (MountRequest) msg;
+                writer.writeLong(mountRequest.clientHighWaterMark);
+                writer.writeLong(mountRequest.seqNum);
+                break;
+
+            case MessageType.MOUNT_RESPONSE:
+                MountResponse mountResponse = (MountResponse) msg;
+                writer.writeInt(mountResponse.partitionState);
+                break;
+
+            case MessageType.APPEND_REQUEST:
+                AppendRequest appendRequest = (AppendRequest) msg;
+                writer.writeLong(appendRequest.clientHighWaterMark);
+                writer.writeIntArray(appendRequest.writeLockRequest);
+                writer.writeIntArray(appendRequest.readLockRequest);
+                writer.writeIntArray(appendRequest.appendLockRequest);
+                writer.writeInt(appendRequest.header);
+                writer.writeByteArray(appendRequest.data);
+                writer.writeInt(appendRequest.checksum);
+                break;
+
+            case MessageType.FEED_REQUEST:
+                FeedRequest feedRequest = (FeedRequest) msg;
+                writer.writeLong(feedRequest.clientHighWaterMark);
+                break;
+
+            case MessageType.FEED_DATA:
+                FeedData feedData = (FeedData) msg;
+                writer.writeLong(feedData.transactionId);
+                writer.writeInt(feedData.header);
+                break;
+
+            case MessageType.FEED_SUSPENDED:
+                break;
+
+            case MessageType.TRANSACTION_DATA_REQUEST:
+                TransactionDataRequest dataRequest = (TransactionDataRequest) msg;
+                writer.writeLong(dataRequest.transactionId);
+                break;
+
+            case MessageType.TRANSACTION_DATA_RESPONSE:
+                TransactionDataResponse dataResponse = (TransactionDataResponse) msg;
+                writer.writeLong(dataResponse.transactionId);
+                if (dataResponse.data != null) {
+                    writer.writeBoolean(true);
+                    writer.writeByteArray(dataResponse.data);
+                    writer.writeInt(dataResponse.checksum);
+                } else if (dataResponse.exception != null) {
+                    writer.writeBoolean(false);
+                    writer.writeString(dataResponse.exception.getMessage());
+                } else {
+                    throw new IllegalStateException("corrupted message: " + msg.type());
+                }
+                break;
+
+            case MessageType.FLUSH_REQUEST:
+                break;
+
+            case MessageType.FLUSH_RESPONSE:
+                FlushResponse flushResponse = (FlushResponse) msg;
+                writer.writeLong(flushResponse.transactionId);
+                break;
+
+            case MessageType.HIGH_WATER_MARK_REQUEST:
+                break;
+
+            case MessageType.HIGH_WATER_MARK_RESPONSE:
+                HighWaterMarkResponse highWaterMarkResponse = (HighWaterMarkResponse) msg;
+                writer.writeLong(highWaterMarkResponse.transactionId);
+                break;
+
+            case MessageType.LOCK_FAILURE:
+                LockFailure lockFailure = (LockFailure) msg;
+                writer.writeLong(lockFailure.transactionId);
+                break;
+
+            case MessageType.CHECK_STORAGE_CONNECTIVITY_REQUEST:
+                break;
+
+            case MessageType.CHECK_STORAGE_CONNECTIVITY_RESPONSE:
+                CheckStorageConnectivityResponse checkStorageConnectivityResponse =
+                    (CheckStorageConnectivityResponse) msg;
+                int size = checkStorageConnectivityResponse.storageConnectivityMap.size();
+                writer.writeInt(size);
+                Map<String, Boolean> storageConnectivityMap = checkStorageConnectivityResponse.storageConnectivityMap;
+                for (Map.Entry<String, Boolean> storageConnectionEntry : storageConnectivityMap.entrySet()) {
+                    writer.writeString(storageConnectionEntry.getKey());
+                    writer.writeBoolean(storageConnectionEntry.getValue());
+                }
+                break;
+
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_REQUEST:
+                break;
+
+            case MessageType.SERVER_PARTITIONS_ASSIGNMENT_RESPONSE:
+                ServerPartitionsAssignmentResponse serverPartitionsAssignmentResponse =
+                    (ServerPartitionsAssignmentResponse) msg;
+                List<Integer> partitionsAssigned = serverPartitionsAssignmentResponse.serverPartitionAssignments;
+                writeListWriter(writer, partitionsAssigned);
+                break;
+
+            case MessageType.SERVER_PARTITIONS_HEALTH_STAT_REQUEST:
+                break;
+
+            case MessageType.SERVER_PARTITIONS_HEALTH_STAT_RESPONSE:
+                ServerPartitionsHealthStatResponse serverPartitionsHealthStatResponse =
+                    (ServerPartitionsHealthStatResponse) msg;
+                size = serverPartitionsHealthStatResponse.serverPartitionHealthStats.size();
+                writer.writeInt(size);
+                Map<Integer, Boolean> serverPartitionHealthStats = serverPartitionsHealthStatResponse.serverPartitionHealthStats;
+                for (Map.Entry<Integer, Boolean> serverPartitionHealthEntry : serverPartitionHealthStats.entrySet()) {
+                    writer.writeInt(serverPartitionHealthEntry.getKey());
+                    writer.writeBoolean(serverPartitionHealthEntry.getValue());
+                }
+                break;
+
+            case MessageType.ADD_PREFERRED_PARTITION_REQUEST:
+                AddPreferredPartitionRequest addPreferredPartitionRequest = (AddPreferredPartitionRequest) msg;
+                writeListWriter(writer, addPreferredPartitionRequest.partitionIds);
+                break;
+
+            case MessageType.ADD_PREFERRED_PARTITION_RESPONSE:
+                AddPreferredPartitionResponse addPreferredPartitionResponse = (AddPreferredPartitionResponse) msg;
+                writer.writeBoolean(addPreferredPartitionResponse.result);
+                break;
+
+            case MessageType.REMOVE_PREFERRED_PARTITION_REQUEST:
+                RemovePreferredPartitionRequest removePreferredPartitionRequest = (RemovePreferredPartitionRequest) msg;
+                writeListWriter(writer, removePreferredPartitionRequest.partitionIds);
+                break;
+
+            case MessageType.REMOVE_PREFERRED_PARTITION_RESPONSE:
+                RemovePreferredPartitionResponse removePreferredPartitionResponse =
+                    (RemovePreferredPartitionResponse) msg;
+                writer.writeBoolean(removePreferredPartitionResponse.result);
+                break;
+
+            default:
+                throw new IllegalStateException("unknown message type: " + msg.type());
+        }
+    }
+
+    private List<Integer> buildListReader(MessageAttributeReader reader) {
+        int listSize = reader.readInt();
+        List<Integer> list = new ArrayList<>(listSize);
+        for (int i = 0; i < listSize; i++) {
+            list.add(reader.readInt());
+        }
+        return list;
+    }
+
+    private void writeListWriter(MessageAttributeWriter writer, List<Integer> list) {
+        writer.writeInt(list.size());
+        for (Integer partition : list) {
+            writer.writeInt(partition);
+        }
+    }
+}

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageType.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/MessageType.java
@@ -27,5 +27,7 @@ public final class MessageType {
     public static final int ADD_PREFERRED_PARTITION_RESPONSE = 18;
     public static final int REMOVE_PREFERRED_PARTITION_REQUEST = 19;
     public static final int REMOVE_PREFERRED_PARTITION_RESPONSE = 20;
+    public static final int SERVER_PARTITIONS_HEALTH_STAT_REQUEST = 21;
+    public static final int SERVER_PARTITIONS_HEALTH_STAT_RESPONSE = 22;
 
 }

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/ServerPartitionsHealthStatRequest.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/ServerPartitionsHealthStatRequest.java
@@ -1,0 +1,13 @@
+package com.wepay.waltz.common.message;
+
+public class ServerPartitionsHealthStatRequest extends AbstractMessage {
+
+    public ServerPartitionsHealthStatRequest(ReqId reqId) {
+        super(reqId);
+    }
+
+    @Override
+    public byte type() {
+        return MessageType.SERVER_PARTITIONS_HEALTH_STAT_REQUEST;
+    }
+}

--- a/waltz-common/src/main/java/com/wepay/waltz/common/message/ServerPartitionsHealthStatResponse.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/common/message/ServerPartitionsHealthStatResponse.java
@@ -1,0 +1,18 @@
+package com.wepay.waltz.common.message;
+
+import java.util.Map;
+
+public class ServerPartitionsHealthStatResponse extends AbstractMessage {
+
+    public final Map<Integer, Boolean> serverPartitionHealthStats;
+
+    public ServerPartitionsHealthStatResponse(ReqId reqId, Map<Integer, Boolean> partitionHealthStats) {
+        super(reqId);
+        this.serverPartitionHealthStats = partitionHealthStats;
+    }
+
+    @Override
+    public byte type() {
+        return MessageType.SERVER_PARTITIONS_HEALTH_STAT_RESPONSE;
+    }
+}

--- a/waltz-common/src/test/java/com/wepay/waltz/common/message/MessageCodecV4Test.java
+++ b/waltz-common/src/test/java/com/wepay/waltz/common/message/MessageCodecV4Test.java
@@ -1,0 +1,187 @@
+package com.wepay.waltz.common.message;
+
+import com.wepay.riff.message.ByteArrayMessageAttributeReader;
+import com.wepay.riff.message.ByteArrayMessageAttributeWriter;
+import com.wepay.riff.network.Message;
+import com.wepay.waltz.common.util.Utils;
+import com.wepay.waltz.exception.RpcException;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MessageCodecV4Test {
+
+    private final MessageCodecV4 codec = new MessageCodecV4();
+    private final Random rand = new Random();
+
+    @Test
+    public void test() {
+        assertEquals(4, codec.version());
+
+        int[] writeLockRequest = lock();
+        int[] readLockRequest = lock();
+        int[] appendLockRequest = lock();
+        int header = rand.nextInt();
+        byte[] data;
+
+        data = data();
+        AppendRequest appendRequest1 = new AppendRequest(reqId(), rand.nextLong(), writeLockRequest, readLockRequest, appendLockRequest, header, data, Utils.checksum(data));
+        AppendRequest appendRequest2 = encodeThenDecode(appendRequest1);
+        assertEquals(MessageType.APPEND_REQUEST, appendRequest1.type());
+        assertEquals(appendRequest1.type(), appendRequest2.type());
+        assertEquals(appendRequest1.reqId, appendRequest2.reqId);
+        assertEquals(appendRequest1.clientHighWaterMark, appendRequest2.clientHighWaterMark);
+        assertTrue(Arrays.equals(appendRequest1.data, appendRequest2.data));
+
+        MountRequest mountRequest1 = new MountRequest(reqId(), rand.nextLong(), rand.nextLong());
+        MountRequest mountRequest2 = encodeThenDecode(mountRequest1);
+        assertEquals(MessageType.MOUNT_REQUEST, mountRequest1.type());
+        assertEquals(mountRequest1.type(), mountRequest2.type());
+        assertEquals(mountRequest1.reqId, mountRequest2.reqId);
+        assertEquals(mountRequest1.clientHighWaterMark, mountRequest2.clientHighWaterMark);
+        assertEquals(mountRequest1.seqNum, mountRequest2.seqNum);
+
+        MountResponse mountResponse1 = new MountResponse(reqId(), rand.nextInt(3));
+        MountResponse mountResponse2 = encodeThenDecode(mountResponse1);
+        assertEquals(MessageType.MOUNT_RESPONSE, mountResponse1.type());
+        assertEquals(mountResponse1.type(), mountResponse2.type());
+        assertEquals(mountResponse1.reqId, mountResponse2.reqId);
+        assertEquals(mountResponse1.partitionState, mountResponse2.partitionState);
+
+        FeedData feedData1 = new FeedData(reqId(), rand.nextLong(), header);
+        FeedData feedData2 = encodeThenDecode(feedData1);
+        assertEquals(MessageType.FEED_DATA, feedData1.type());
+        assertEquals(feedData1.type(), feedData2.type());
+        assertEquals(feedData1.reqId, feedData2.reqId);
+        assertEquals(feedData1.transactionId, feedData2.transactionId);
+        assertEquals(feedData1.header, feedData2.header);
+
+        FeedRequest feedRequest1 = new FeedRequest(reqId(), rand.nextLong());
+        FeedRequest feedRequest2 = encodeThenDecode(feedRequest1);
+        assertEquals(MessageType.FEED_REQUEST, feedRequest1.type());
+        assertEquals(feedRequest1.type(), feedRequest2.type());
+        assertEquals(feedRequest1.reqId, feedRequest2.reqId);
+        assertEquals(feedRequest1.clientHighWaterMark, feedRequest2.clientHighWaterMark);
+
+        FeedSuspended feedSuspended1 = new FeedSuspended(reqId());
+        FeedSuspended feedSuspended2 = encodeThenDecode(feedSuspended1);
+        assertEquals(MessageType.FEED_SUSPENDED, feedSuspended1.type());
+        assertEquals(feedSuspended1.type(), feedSuspended2.type());
+        assertEquals(feedSuspended1.reqId, feedSuspended2.reqId);
+
+        FlushRequest flushRequest1 = new FlushRequest(reqId());
+        FlushRequest flushRequest2 = encodeThenDecode(flushRequest1);
+        assertEquals(MessageType.FLUSH_REQUEST, flushRequest1.type());
+        assertEquals(flushRequest1.type(), flushRequest2.type());
+        assertEquals(flushRequest1.reqId, flushRequest2.reqId);
+
+        FlushResponse flushResponse1 = new FlushResponse(reqId(), rand.nextLong());
+        FlushResponse flushResponse2 = encodeThenDecode(flushResponse1);
+        assertEquals(MessageType.FLUSH_RESPONSE, flushResponse1.type());
+        assertEquals(flushResponse1.type(), flushResponse2.type());
+        assertEquals(flushResponse1.reqId, flushResponse2.reqId);
+        assertEquals(flushResponse1.transactionId, flushResponse2.transactionId);
+
+        TransactionDataRequest transactionDataRequest1 = new TransactionDataRequest(reqId(), rand.nextLong());
+        TransactionDataRequest transactionDataRequest2 = encodeThenDecode(transactionDataRequest1);
+        assertEquals(MessageType.TRANSACTION_DATA_REQUEST, transactionDataRequest1.type());
+        assertEquals(transactionDataRequest1.type(), transactionDataRequest2.type());
+        assertEquals(transactionDataRequest1.reqId, transactionDataRequest2.reqId);
+        assertEquals(transactionDataRequest1.transactionId, transactionDataRequest2.transactionId);
+
+        TransactionDataResponse transactionDataResponse1 =
+            new TransactionDataResponse(reqId(), rand.nextLong(), data, Utils.checksum(data));
+        TransactionDataResponse transactionDataResponse2 = encodeThenDecode(transactionDataResponse1);
+        assertEquals(MessageType.TRANSACTION_DATA_RESPONSE, transactionDataResponse1.type());
+        assertEquals(transactionDataResponse1.type(), transactionDataResponse2.type());
+        assertEquals(transactionDataResponse1.reqId, transactionDataResponse2.reqId);
+        assertEquals(transactionDataResponse1.transactionId, transactionDataResponse2.transactionId);
+        assertNotNull(transactionDataResponse1.data);
+        assertNotNull(transactionDataResponse2.data);
+        assertNull(transactionDataResponse1.exception);
+        assertNull(transactionDataResponse2.exception);
+        assertTrue(Arrays.equals(transactionDataResponse1.data, transactionDataResponse2.data));
+        assertEquals(transactionDataResponse1.checksum, transactionDataResponse2.checksum);
+
+        TransactionDataResponse transactionDataResponse3 =
+            new TransactionDataResponse(reqId(), rand.nextLong(), new RpcException(Integer.toString(rand.nextInt())));
+        TransactionDataResponse transactionDataResponse4 = encodeThenDecode(transactionDataResponse3);
+        assertEquals(MessageType.TRANSACTION_DATA_RESPONSE, transactionDataResponse1.type());
+        assertEquals(transactionDataResponse3.type(), transactionDataResponse4.type());
+        assertEquals(transactionDataResponse3.reqId, transactionDataResponse4.reqId);
+        assertEquals(transactionDataResponse3.transactionId, transactionDataResponse4.transactionId);
+        assertNull(transactionDataResponse3.data);
+        assertNull(transactionDataResponse4.data);
+        assertEquals(0, transactionDataResponse3.checksum);
+        assertEquals(0, transactionDataResponse4.checksum);
+        assertNotNull(transactionDataResponse3.exception);
+        assertNotNull(transactionDataResponse4.exception);
+        assertEquals(transactionDataResponse3.exception.toString(), transactionDataResponse4.exception.toString());
+
+        HighWaterMarkRequest highWaterMarkRequest1 = new HighWaterMarkRequest(reqId());
+        HighWaterMarkRequest highWaterMarkRequest2 = encodeThenDecode(highWaterMarkRequest1);
+        assertEquals(MessageType.HIGH_WATER_MARK_REQUEST, highWaterMarkRequest1.type());
+        assertEquals(highWaterMarkRequest1.type(), highWaterMarkRequest2.type());
+        assertEquals(highWaterMarkRequest1.reqId, highWaterMarkRequest2.reqId);
+
+        HighWaterMarkResponse highWaterMarkResponse1 = new HighWaterMarkResponse(reqId(), rand.nextLong());
+        HighWaterMarkResponse highWaterMarkResponse2 = encodeThenDecode(highWaterMarkResponse1);
+        assertEquals(MessageType.HIGH_WATER_MARK_RESPONSE, highWaterMarkResponse1.type());
+        assertEquals(highWaterMarkResponse1.type(), highWaterMarkResponse2.type());
+        assertEquals(highWaterMarkResponse1.reqId, highWaterMarkResponse2.reqId);
+        assertEquals(highWaterMarkResponse1.transactionId, highWaterMarkResponse2.transactionId);
+
+        ServerPartitionsHealthStatRequest serverPartitionsHealthStatRequest1 = new ServerPartitionsHealthStatRequest(reqId());
+        ServerPartitionsHealthStatRequest serverPartitionsHealthStatRequest2 = encodeThenDecode(serverPartitionsHealthStatRequest1);
+        assertEquals(MessageType.SERVER_PARTITIONS_HEALTH_STAT_REQUEST, serverPartitionsHealthStatRequest1.type());
+        assertEquals(serverPartitionsHealthStatRequest1.type(), serverPartitionsHealthStatRequest2.type());
+        assertEquals(serverPartitionsHealthStatRequest1.reqId, serverPartitionsHealthStatRequest2.reqId);
+
+        ServerPartitionsHealthStatResponse serverPartitionsHealthStatResponse1 =
+            new ServerPartitionsHealthStatResponse(reqId(), new HashMap<Integer, Boolean>() {{
+                put(rand.nextInt(), rand.nextBoolean());
+            }});
+        ServerPartitionsHealthStatResponse serverPartitionsHealthStatResponse2 = encodeThenDecode(serverPartitionsHealthStatResponse1);
+        assertEquals(MessageType.SERVER_PARTITIONS_HEALTH_STAT_RESPONSE, serverPartitionsHealthStatResponse1.type());
+        assertEquals(serverPartitionsHealthStatResponse1.type(), serverPartitionsHealthStatResponse2.type());
+        assertEquals(serverPartitionsHealthStatResponse1.reqId, serverPartitionsHealthStatResponse2.reqId);
+        assertEquals(serverPartitionsHealthStatResponse1.serverPartitionHealthStats, serverPartitionsHealthStatResponse2.serverPartitionHealthStats);
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Message> T encodeThenDecode(T message) {
+        ByteArrayMessageAttributeWriter writer = new ByteArrayMessageAttributeWriter();
+        codec.encode(message, writer);
+        ByteArrayMessageAttributeReader reader = new ByteArrayMessageAttributeReader(writer.toByteArray());
+        return (T) codec.decode(reader);
+    }
+
+    private ReqId reqId() {
+        return new ReqId(rand.nextLong(), rand.nextLong());
+    }
+
+    private int[] lock() {
+        int n = rand.nextInt(3);
+        int[] lock = new int[n];
+
+        for (int i = 0; i < n; i++) {
+            lock[i] = rand.nextInt();
+        }
+
+        return lock;
+    }
+
+    private byte[] data() {
+        return Long.toOctalString(rand.nextLong()).getBytes(StandardCharsets.UTF_8);
+    }
+
+}

--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
@@ -14,12 +14,15 @@ import com.wepay.waltz.common.message.MessageCodecV0;
 import com.wepay.waltz.common.message.MessageCodecV1;
 import com.wepay.waltz.common.message.MessageCodecV2;
 import com.wepay.waltz.common.message.MessageCodecV3;
+import com.wepay.waltz.common.message.MessageCodecV4;
 import com.wepay.waltz.common.message.MessageType;
 import com.wepay.waltz.common.message.MountRequest;
 import com.wepay.waltz.common.message.RemovePreferredPartitionRequest;
 import com.wepay.waltz.common.message.RemovePreferredPartitionResponse;
 import com.wepay.waltz.common.message.ServerPartitionsAssignmentRequest;
 import com.wepay.waltz.common.message.ServerPartitionsAssignmentResponse;
+import com.wepay.waltz.common.message.ServerPartitionsHealthStatRequest;
+import com.wepay.waltz.common.message.ServerPartitionsHealthStatResponse;
 import com.wepay.waltz.common.metadata.ReplicaId;
 import com.wepay.waltz.storage.client.StorageClient;
 import com.wepay.waltz.store.Store;
@@ -55,6 +58,7 @@ public class WaltzServerHandler extends MessageHandler implements PartitionClien
         CODECS.put(MessageCodecV1.VERSION, MessageCodecV1.INSTANCE);
         CODECS.put(MessageCodecV2.VERSION, MessageCodecV2.INSTANCE);
         CODECS.put(MessageCodecV3.VERSION, MessageCodecV3.INSTANCE);
+        CODECS.put(MessageCodecV4.VERSION, MessageCodecV4.INSTANCE);
     }
 
     private static final String HELLO_MESSAGE = "Waltz Server";
@@ -146,6 +150,18 @@ public class WaltzServerHandler extends MessageHandler implements PartitionClien
                 }
                 sendMessage(new ServerPartitionsAssignmentResponse(((ServerPartitionsAssignmentRequest) msg).reqId,
                         partitionsAssigned), true);
+                break;
+
+            case MessageType.SERVER_PARTITIONS_HEALTH_STAT_REQUEST:
+                Map<Integer, Boolean> partitionHealthStats;
+
+                synchronized (partitions) {
+                    partitionHealthStats = partitions.values().stream()
+                        .collect(Collectors.toMap(partition -> partition.partitionId, Partition::isHealthy));
+                }
+                System.out.println(partitionHealthStats);
+                sendMessage(new ServerPartitionsHealthStatResponse(((ServerPartitionsHealthStatRequest) msg).reqId,
+                    partitionHealthStats), true);
                 break;
 
             case MessageType.ADD_PREFERRED_PARTITION_REQUEST:

--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/WaltzServerHandler.java
@@ -159,7 +159,6 @@ public class WaltzServerHandler extends MessageHandler implements PartitionClien
                     partitionHealthStats = partitions.values().stream()
                         .collect(Collectors.toMap(partition -> partition.partitionId, Partition::isHealthy));
                 }
-                System.out.println(partitionHealthStats);
                 sendMessage(new ServerPartitionsHealthStatResponse(((ServerPartitionsHealthStatRequest) msg).reqId,
                     partitionHealthStats), true);
                 break;

--- a/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
+++ b/waltz-tools/src/main/java/com/wepay/waltz/tools/cluster/ClusterCli.java
@@ -282,9 +282,6 @@ public final class ClusterCli extends SubcommandCli {
                     partitionToStorageStatusMap, partitionsValidationResultList);
 
                 // Step5: Validate server partitions are healthy
-                rpcClient = new InternalRpcClient(sslContext, WaltzClientConfig.DEFAULT_MAX_CONCURRENT_TRANSACTIONS,
-                    new DummyTxnCallbacks());
-
                 CompletableFuture<Void> partitionHealthValidationFuture =
                     buildServersPartitionHealthValidation(
                         rpcClient, clusterManager, partitionsValidationResultList

--- a/waltz-tools/src/test/java/com/wepay/waltz/tools/cluster/ClusterCliTest.java
+++ b/waltz-tools/src/test/java/com/wepay/waltz/tools/cluster/ClusterCliTest.java
@@ -167,6 +167,9 @@ public class ClusterCliTest {
             assertFalse(outContent.toString("UTF-8")
                 .contains("Validation SERVER_STORAGE_CONNECTIVITY failed"));
 
+            assertFalse(outContent.toString("UTF-8")
+                .contains("Validation SERVER_PARTITION_HEALTH_CHECK failed"));
+
             // Check that the storage partition assignment on ZooKeeper match with that on the storage nodes only for
             // Partition 1.
             assertTrue(outContent.toString("UTF-8")
@@ -287,6 +290,10 @@ public class ClusterCliTest {
             // Check that REPLICA_RECOVERY_STATUS verification didn't fail
             assertFalse(outContent.toString("UTF-8")
                 .contains("Validation REPLICA_RECOVERY_STATUS failed for partition " + partitionId));
+
+            // Check that server partitions are healthy
+            assertFalse(outContent.toString("UTF-8")
+                .contains("Validation SERVER_PARTITION_HEALTH_CHECK failed for partition " + partitionId));
 
             // Close the server network connection
             WaltzServerRunner waltzServerRunner = helper.getWaltzServerRunner(helper.getServerPort(),


### PR DESCRIPTION
**Goal:** Empower ClusterCli.Verify with an additional check. The check connects to all servers in a cluster and gets health status of partitions assigned to every server. This provides the benefit of on demand check of all servers /health endpoints.

New MessageCodecV4 introduced with 2 new message types:

- SERVER_PARTITIONS_HEALTH_STAT_REQUEST
- SERVER_PARTITIONS_HEALTH_STAT_RESPONSE

**Testing:** The easiest way to verify functionality of this PR is by utilizing tests in the ClusterCliTest class.