### PR TITLE
Partition.isValid null check fix

### DIFF
--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/Partition.java
@@ -415,16 +415,16 @@ public class Partition {
 
     private boolean isValid(PartitionClient client) {
         synchronized (partitionClientConnectionInfos) {
-            Long currentSeqNum = partitionClientConnectionInfos.get(client.clientId()).client.seqNum();
-            if (currentSeqNum == null) {
-                logger.info(String.format("CurrentSeqNum is null. PartitionClient not valid. ClientId: %s, PartitionId: %d, "
-                        + "WaltzServerHandler SeqNum: %s",
+            ClientConnectionInfo currentClientConnectionInfo = partitionClientConnectionInfos.get(client.clientId());
+            if (currentClientConnectionInfo == null) {
+                logger.info(String.format("CurrentClientConnectionInfo is null. PartitionClient not valid. "
+                        + "ClientId: %s, PartitionId: %d, WaltzServerHandler SeqNum: %s",
                     client.clientId(), partitionId, client.seqNum()));
                 return false;
-            } else if (!currentSeqNum.equals(client.seqNum())) {
+            } else if (!currentClientConnectionInfo.client.seqNum().equals(client.seqNum())) {
                 logger.info(String.format("CurrentSeqNum is not equal to WaltzServerHandler seqNum. PartitionClient not valid. "
                         + "WaltzServerHandler seqNum %d, PartitionId: %d, CurrentSeqNum: %d",
-                    client.clientId(), partitionId, currentSeqNum));
+                    client.clientId(), partitionId, currentClientConnectionInfo.client.seqNum()));
                 return false;
             } else {
                 return true;


### PR DESCRIPTION
Null check fix for the case when PartitionClient is not valid because we don't have a record of it in partitionClientConnectionInfos map.

If client is not null, currentClientConnectionInfo.client.seqNum() can't be null because we store in partitionClientConnectionInfos map ClientConnectionInfo objects based on their seqNum.