### PR TITLE
Release Waltz 0.13.0 - Execute Publish Job, Execute Release Job

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ project.ext {
     assertjVersion = '3.8.0'
     zkToolsVersion = '0.7.3'
     yamlVersion = '1.20'
-    riffVersion = '2.5.1'
+    riffVersion = '2.5.2'
     jacksonVersion = '2.9.6'
     jettyVersion = '9.4.12.v20180830'
     mainClass = 'Main'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.waltz
 sourceCompatibility=1.8
-version=0.12.1
+version=0.13.0


### PR DESCRIPTION
Release Waltz version 0.13.0

**Note:** Once this PR is merged, Waltz version 0.13.0 will be automatically released to Maven Central

**Changes include:**
- Fix preventing no longer used WaltzServerHandler from removing connection information of currently used WaltzServerHandler in a timing error
- Storage partition health refers to overall partition health instead of only failed partition recovery error
- Cluster state verification includes check of server partition's health
- Fix to prevent deadlock if number of replicas is 0
- Support of running Waltz locally in Docker on M1 chips
- Unregister server partition metrics only after successful completion of partition closure
- Waltz release to MavenCentral automation