### PR TITLE
Bugfix for ClusterCli.Verify

### DIFF
--- a/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandler.java
+++ b/waltz-client/src/main/java/com/wepay/waltz/client/internal/network/WaltzClientHandler.java
@@ -164,6 +164,7 @@ public class WaltzClientHandler extends MessageHandler {
                 ServerPartitionsHealthStatResponse serverPartitionsHealthStatResponse =
                     (ServerPartitionsHealthStatResponse) msg;
                 handlerCallbacks.onServerPartitionsHealthStatsReceived(serverPartitionsHealthStatResponse.serverPartitionHealthStats);
+                break;
 
             default:
                 throw new IllegalArgumentException("message not handled: messageType=" + msg.type());


### PR DESCRIPTION
A bugfix fixing connection restart during ClusterCli.Verify CLI call that is followed by `com.wepay.waltz.client.internal.InternalBaseClient  - recovering from connection loss` message.