### PR TITLE
Release Waltz 0.13.1 - Execute Publish Job, Execute Release Job

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.waltz
 sourceCompatibility=1.8
-version=0.13.0
+version=0.13.1


### PR DESCRIPTION
Release Waltz 0.13.1

Changes:
Fixed bug in ClusterCli verify call

Note:
Once merged, 0.13.1 version of Waltz will be automatically released