### PR TITLE
EnsureMounted Timeout

### DIFF
--- a/waltz-common/src/main/java/com/wepay/waltz/exception/ClientTimeoutException.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/exception/ClientTimeoutException.java
@@ -1,0 +1,7 @@
+package com.wepay.waltz.exception;
+
+public class ClientTimeoutException extends ClientException {
+    public ClientTimeoutException(String message) {
+        super(message);
+    }
+}

--- a/waltz-common/src/main/java/com/wepay/waltz/exception/WaitForMountedTimeoutException.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/exception/WaitForMountedTimeoutException.java
@@ -1,0 +1,7 @@
+package com.wepay.waltz.exception;
+
+public class WaitForMountedTimeoutException extends ClientException {
+    public WaitForMountedTimeoutException(int partitionId, int timeout) {
+        super(String.format("client couldn't ensure that partition: %d is mounted within %d ms", partitionId, timeout));
+    }
+}

--- a/waltz-common/src/main/java/com/wepay/waltz/exception/WaitForMountedTimeoutException.java
+++ b/waltz-common/src/main/java/com/wepay/waltz/exception/WaitForMountedTimeoutException.java
@@ -1,7 +1,0 @@
-package com.wepay.waltz.exception;
-
-public class WaitForMountedTimeoutException extends ClientException {
-    public WaitForMountedTimeoutException(int partitionId, int timeout) {
-        super(String.format("client couldn't ensure that partition: %d is mounted within %d ms", partitionId, timeout));
-    }
-}


### PR DESCRIPTION
Introducing timeout of 10s to Client's Partition EnsureMounted(), after which a WaitForMountedTimeoutException is thrown.

This exception acts as other exceptions thrown in this method and is handled by methods invoking waltzClient.submit() that are part of Waltz client services.

Testing: The easiest way to test the code is through WaltzServerTest.testConcurrencyControlMultipleLocks 