### PR TITLE
feedTask not getting garbage collected

### DIFF
--- a/waltz-server/src/main/java/com/wepay/waltz/server/internal/FeedContext.java
+++ b/waltz-server/src/main/java/com/wepay/waltz/server/internal/FeedContext.java
@@ -12,7 +12,15 @@ import java.util.Comparator;
 public class FeedContext {
 
     public static final Comparator<FeedContext> HIGH_WATER_MARK_COMPARATOR =
-        (o1, o2) -> o1.highWaterMark < o2.highWaterMark ? -1 : o1.highWaterMark > o2.highWaterMark ? 1 : 0;
+        (o1, o2) -> {
+            int hwmCompare = Long.compare(o1.highWaterMark, o2.highWaterMark);
+
+            if (hwmCompare == 0) {
+                return Integer.compare(o1.reqId.seqNum(), o2.reqId.seqNum());
+            }
+
+            return hwmCompare;
+        };
 
     public final ReqId reqId;
     public final PartitionClient sender;


### PR DESCRIPTION
When no append requests are happening on a certain partition, feed contexts may accumulate on the real time feed task queue of that partition server in case of a disconnection between a Waltz client and the server holding that partition.